### PR TITLE
Colored coin address

### DIFF
--- a/lib/tapyrus/chain_params.rb
+++ b/lib/tapyrus/chain_params.rb
@@ -10,6 +10,8 @@ module Tapyrus
     attr_reader :message_magic
     attr_reader :address_version
     attr_reader :p2sh_version
+    attr_reader :cp2pkh_version
+    attr_reader :cp2sh_version
     attr_reader :bech32_hrp
     attr_reader :privkey_version
     attr_reader :extended_privkey_version

--- a/lib/tapyrus/chainparams/dev.yml
+++ b/lib/tapyrus/chainparams/dev.yml
@@ -4,6 +4,8 @@ magic_head: "0b110907"
 message_magic: "Bitcoin Signed Message:\n"
 address_version: "6f"
 p2sh_version: "c4"
+cp2pkh_version: "70"
+cp2sh_version: "c5"
 bech32_hrp: 'tb'
 privkey_version: "ef"
 extended_privkey_version: "04358394"

--- a/lib/tapyrus/chainparams/prod.yml
+++ b/lib/tapyrus/chainparams/prod.yml
@@ -4,6 +4,8 @@ magic_head: "f9beb4d9"
 message_magic: "Bitcoin Signed Message:\n"
 address_version: "00"
 p2sh_version: "05"
+cp2pkh_version: "01"
+cp2sh_version: "06"
 bech32_hrp: 'bc'
 privkey_version: "80"
 extended_privkey_version: "0488ade4"

--- a/lib/tapyrus/script/script.rb
+++ b/lib/tapyrus/script/script.rb
@@ -63,7 +63,10 @@ module Tapyrus
     # Add color identifier to existing p2pkh or p2sh
     # @param [ColorIdentifier] color identifier
     # @return [Script] CP2PKH or CP2SH script
+    # @raise [ArgumentError] if color_id is nil or invalid
+    # @raise [RuntimeError] if script is neither p2pkh nor p2sh
     def add_color(color_id)
+      raise ArgumentError, 'Specified color identifier is invalid' unless color_id&.valid?
       raise RuntimeError, 'Only p2pkh and p2sh can add color' unless p2pkh? or p2sh?
       Tapyrus::Script.new.tap do |s|
         s << color_id.to_payload << OP_COLOR

--- a/lib/tapyrus/script/script.rb
+++ b/lib/tapyrus/script/script.rb
@@ -521,17 +521,27 @@ module Tapyrus
     # generate cp2pkh address. if script dose not cp2pkh, return nil.
     def cp2pkh_addr
       return nil unless cp2pkh?
+
+      color_id = chunks[0].pushed_data.bth
+      return nil unless Tapyrus::Color::ColorIdentifier.parse_from_payload(color_id.htb)&.valid?
+
       hash160 = chunks[4].pushed_data.bth
       return nil unless hash160.htb.bytesize == 20
-      Tapyrus.encode_base58_address(hash160, Tapyrus.chain_params.address_version)
+
+      Tapyrus.encode_base58_address(color_id + hash160, Tapyrus.chain_params.cp2pkh_version)
     end
 
     # generate cp2sh address. if script dose not cp2sh, return nil.
     def cp2sh_addr
       return nil unless cp2sh?
+
+      color_id = chunks[0].pushed_data.bth
+      return nil unless Tapyrus::Color::ColorIdentifier.parse_from_payload(color_id.htb)&.valid?
+
       hash160 = chunks[3].pushed_data.bth
       return nil unless hash160.htb.bytesize == 20
-      Tapyrus.encode_base58_address(hash160, Tapyrus.chain_params.p2sh_version)
+
+      Tapyrus.encode_base58_address(color_id + hash160, Tapyrus.chain_params.cp2sh_version)
     end
   end
 

--- a/lib/tapyrus/script/script.rb
+++ b/lib/tapyrus/script/script.rb
@@ -508,7 +508,6 @@ module Tapyrus
     def p2pkh_addr
       return nil unless p2pkh?
       hash160 = chunks[2].pushed_data.bth
-      return nil unless hash160.htb.bytesize == 20
       Tapyrus.encode_base58_address(hash160, Tapyrus.chain_params.address_version)
     end
 
@@ -516,7 +515,6 @@ module Tapyrus
     def p2sh_addr
       return nil unless p2sh?
       hash160 = chunks[1].pushed_data.bth
-      return nil unless hash160.htb.bytesize == 20
       Tapyrus.encode_base58_address(hash160, Tapyrus.chain_params.p2sh_version)
     end
 
@@ -526,8 +524,6 @@ module Tapyrus
 
       color_id = chunks[0].pushed_data.bth
       hash160 = chunks[4].pushed_data.bth
-      return nil unless hash160.htb.bytesize == 20
-
       Tapyrus.encode_base58_address(color_id + hash160, Tapyrus.chain_params.cp2pkh_version)
     end
 
@@ -537,8 +533,6 @@ module Tapyrus
 
       color_id = chunks[0].pushed_data.bth
       hash160 = chunks[3].pushed_data.bth
-      return nil unless hash160.htb.bytesize == 20
-
       Tapyrus.encode_base58_address(color_id + hash160, Tapyrus.chain_params.cp2sh_version)
     end
   end

--- a/lib/tapyrus/script/script.rb
+++ b/lib/tapyrus/script/script.rb
@@ -216,6 +216,7 @@ module Tapyrus
     def cp2pkh?
       return false unless chunks.size == 7
       return false unless chunks[0].bytesize == 34
+      return false unless Tapyrus::Color::ColorIdentifier.parse_from_payload(chunks[0].pushed_data)&.valid?
       return false unless chunks[1].ord == OP_COLOR
       [OP_DUP, OP_HASH160, OP_EQUALVERIFY, OP_CHECKSIG] ==
           (chunks[2..3]+ chunks[5..6]).map(&:ord) && chunks[4].bytesize == 21
@@ -224,6 +225,7 @@ module Tapyrus
     def cp2sh?
       return false unless chunks.size == 5
       return false unless chunks[0].bytesize == 34
+      return false unless Tapyrus::Color::ColorIdentifier.parse_from_payload(chunks[0].pushed_data)&.valid?
       return false unless chunks[1].ord == OP_COLOR
       OP_HASH160 == chunks[2].ord && OP_EQUAL == chunks[4].ord && chunks[3].bytesize == 21
     end
@@ -523,8 +525,6 @@ module Tapyrus
       return nil unless cp2pkh?
 
       color_id = chunks[0].pushed_data.bth
-      return nil unless Tapyrus::Color::ColorIdentifier.parse_from_payload(color_id.htb)&.valid?
-
       hash160 = chunks[4].pushed_data.bth
       return nil unless hash160.htb.bytesize == 20
 
@@ -536,8 +536,6 @@ module Tapyrus
       return nil unless cp2sh?
 
       color_id = chunks[0].pushed_data.bth
-      return nil unless Tapyrus::Color::ColorIdentifier.parse_from_payload(color_id.htb)&.valid?
-
       hash160 = chunks[3].pushed_data.bth
       return nil unless hash160.htb.bytesize == 20
 

--- a/spec/tapyrus/script/script_spec.rb
+++ b/spec/tapyrus/script/script_spec.rb
@@ -261,10 +261,25 @@ describe Tapyrus::Script do
       it { expect(subject.cp2pkh?).to be_falsy }
       it { expect(subject.cp2sh?).to be_truthy }
     end
+
     context 'for op_return' do
       let(:script) { Tapyrus::Script.new << OP_RETURN }
 
       it { expect { subject }.to raise_error }
+    end
+
+    context 'when color identifier is not specified' do
+      let(:color) { nil }
+      let(:script) { Tapyrus::Script.to_p2pkh('46c2fbfbecc99a63148fa076de58cf29b0bcf0b0') }
+
+      it { expect { subject }.to raise_error ArgumentError, 'Specified color identifier is invalid' }
+    end
+
+    context 'when color identifier is invalid' do
+      let(:color) { Tapyrus::Color::ColorIdentifier.parse_from_payload("c4ec2fd806701a3f55808cbec3922c38dafaa3070c48c803e9043ee3642c660b46") }
+      let(:script) { Tapyrus::Script.to_p2pkh('46c2fbfbecc99a63148fa076de58cf29b0bcf0b0') }
+
+      it { expect { subject }.to raise_error ArgumentError, 'Specified color identifier is invalid' }
     end
   end
 

--- a/spec/tapyrus/script/script_spec.rb
+++ b/spec/tapyrus/script/script_spec.rb
@@ -157,6 +157,34 @@ describe Tapyrus::Script do
     end
   end
 
+  describe '#cp2pkh?' do
+    subject { Tapyrus::Script.parse_from_payload(payload) }
+
+    let(:payload) { '21c3ec2fd806701a3f55808cbec3922c38dafaa3070c48c803e9043ee3642c660b46bc76a91446c2fbfbecc99a63148fa076de58cf29b0bcf0b088ac'.htb }
+
+    it { expect(subject.cp2pkh?).to be_truthy }
+
+    context 'invalid type' do
+      let(:payload) { '21c4ec2fd806701a3f55808cbec3922c38dafaa3070c48c803e9043ee3642c660b46bc76a91446c2fbfbecc99a63148fa076de58cf29b0bcf0b088ac'.htb }
+
+      it { expect(subject.cp2pkh?).to be_falsy }
+    end
+  end
+
+  describe '#cp2sh?' do
+    subject { Tapyrus::Script.parse_from_payload(payload) }
+
+    let(:payload) { '21c3ec2fd806701a3f55808cbec3922c38dafaa3070c48c803e9043ee3642c660b46bca9147620a79e8657d066cff10e21228bf983cf546ac687'.htb }
+
+    it { expect(subject.cp2sh?).to be_truthy }
+
+    context 'invalid type' do
+      let(:payload) { '21c4ec2fd806701a3f55808cbec3922c38dafaa3070c48c803e9043ee3642c660b46bca9147620a79e8657d066cff10e21228bf983cf546ac687'.htb }
+
+      it { expect(subject.cp2sh?).to be_falsy }
+    end
+  end
+
   describe 'cp2pkh script' do
     subject { Tapyrus::Script.to_cp2pkh(color, '46c2fbfbecc99a63148fa076de58cf29b0bcf0b0') }
 

--- a/spec/tapyrus/script/script_spec.rb
+++ b/spec/tapyrus/script/script_spec.rb
@@ -173,7 +173,7 @@ describe Tapyrus::Script do
       expect(subject.multisig?).to be false
       expect(subject.op_return?).to be false
       expect(subject.standard?).to be false
-      expect(subject.addresses.first).to eq('mmy7BEH1SUGAeSVUR22pt5hPaejo2645F1')
+      expect(subject.addresses.first).to eq('22VdQ5VjWcF9zgsnPQodFBS1PBQPaAQEXSofkyMv2D9zV1MLp3JfScV6TMVaUQ42xeTfjieWssAaefMd')
       expect(subject.get_pubkeys).to eq([])
     end
 
@@ -204,7 +204,7 @@ describe Tapyrus::Script do
       expect(subject.multisig?).to be false
       expect(subject.op_return?).to be false
       expect(subject.standard?).to be false
-      expect(subject.addresses.first).to eq('2N41pqp5vuafHQf39KraznDLEqsSKaKmrij')
+      expect(subject.addresses.first).to eq('2oLdn5UKgY7DayDDLL6LKfrNnHKp7iFK8zGAMHVGd2USnCxi3XmHdMBjrPdXXsoJUCn3R4J1RfbFP2aW')
       expect(subject.get_pubkeys).to eq([])
     end
 

--- a/spec/tapyrus/script/script_spec.rb
+++ b/spec/tapyrus/script/script_spec.rb
@@ -69,6 +69,15 @@ describe Tapyrus::Script do
         expect(subject.addresses.first).to eq('mmy7BEH1SUGAeSVUR22pt5hPaejo2645F1')
       end
     end
+
+    context 'invalid hash(too long)' do
+      subject { Tapyrus::Script.to_p2pkh('46c2fbfbecc99a63148fa076de58cf29b0bcf0b000') }
+
+      it 'should not be treated as P2PKH' do
+        expect(subject.p2pkh?).to be false
+        expect(subject.addresses).to be_empty
+      end
+    end
   end
 
   describe 'p2sh script' do
@@ -99,6 +108,15 @@ describe Tapyrus::Script do
       it 'should be generate P2SH script' do
         expect(subject[0].addresses.first).to eq('2N41pqp5vuafHQf39KraznDLEqsSKaKmrij')
         expect(subject[1].addresses).to eq(['n4jKJN5UMLsAejL1M5CTzQ8npeWoLBLCAH', 'mvqSumyieKezeESrga7dGBmgm7cfuATBvf'])
+      end
+    end
+
+    context 'invalid hash(too long)' do
+      subject { Tapyrus::Script.to_p2sh('7620a79e8657d066cff10e21228bf983cf546ac600') }
+
+      it 'should not be treated as P2SH' do
+        expect(subject.p2sh?).to be_falsy
+        expect(subject.addresses).to be_empty
       end
     end
   end

--- a/spec/tapyrus/script/script_spec.rb
+++ b/spec/tapyrus/script/script_spec.rb
@@ -177,6 +177,10 @@ describe Tapyrus::Script do
       expect(subject.get_pubkeys).to eq([])
     end
 
+    context 'prod', network: :prod do
+      it { expect(subject.addresses.first).to eq('w26x2EaheVBsceNf9RufpmmZ1i1qLBux1UMKMs16dkcZxTP8FBRDXGQ3Cim71aJ1gtoFNttSPNfLsC') }
+    end
+
     context 'when color identifier is not specified' do
       let(:color) { nil }
       it { expect { subject }.to raise_error ArgumentError, 'Specified color identifier is invalid' }
@@ -206,6 +210,10 @@ describe Tapyrus::Script do
       expect(subject.standard?).to be false
       expect(subject.addresses.first).to eq('2oLdn5UKgY7DayDDLL6LKfrNnHKp7iFK8zGAMHVGd2USnCxi3XmHdMBjrPdXXsoJUCn3R4J1RfbFP2aW')
       expect(subject.get_pubkeys).to eq([])
+    end
+
+    context 'prod', network: :prod do
+      it { expect(subject.addresses.first).to eq('4a28F5ZehQNaMsSCEzBGQSKjVx2Wz2c4s32joimPciFTLzc7AUqsfg2xhoBq8NAjEpRNFNUrAZrpEHB') }
     end
 
     context 'when color identifier is not specified' do


### PR DESCRIPTION
Colored coin address is generated as https://gist.github.com/azuchi/712bf84bd01c8e181b2377233ef9952a#address

- Add version bytes to chain_params(prod.yml and dev.yml)
- Update methods to convert Tapyrus#Script to colored coin address(#cp2pkh_addr, #cp2sh_addr)

In addition, 
- add validation to #add_color method to check if color_id as specified parameter is valid or not.