### PR TITLE
Fix multi wallet support

### DIFF
--- a/lib/tapyrus/rpc/tapyrus_core_client.rb
+++ b/lib/tapyrus/rpc/tapyrus_core_client.rb
@@ -57,7 +57,7 @@ module Tapyrus
         uri = URI.parse(server_url)
         http = Net::HTTP.new(uri.hostname, uri.port)
         http.use_ssl = uri.scheme === "https"
-        request = Net::HTTP::Post.new('/')
+        request = Net::HTTP::Post.new(uri.path.empty? ? '/' : uri.path)
         request.basic_auth(uri.user, uri.password)
         request.content_type = 'application/json'
         request.body = data.to_json

--- a/spec/tapyrus/rpc/tapyrus_core_client_spec.rb
+++ b/spec/tapyrus/rpc/tapyrus_core_client_spec.rb
@@ -46,6 +46,15 @@ describe Tapyrus::RPC::TapyrusCoreClient do
         expect(client.rpc_command['amount']).to eq("0.08495981")
       end
     end
+
+    context 'If the wallet is specified in config' do
+      let(:config) { super().merge({ wallet: 'mywallet' }) }
+      let(:server_url) { "#{config[:schema]}://#{config[:host]}:#{config[:port]}/wallet/#{config[:wallet]}" }
+      it 'should have wallet name in the path like "/wallet/[wallet_name]"' do
+        assert_requested(:post, server_url)
+        client.rpc_command
+      end
+    end
   end
 
 end

--- a/spec/tapyrus/rpc/tapyrus_core_client_spec.rb
+++ b/spec/tapyrus/rpc/tapyrus_core_client_spec.rb
@@ -47,7 +47,7 @@ describe Tapyrus::RPC::TapyrusCoreClient do
       end
     end
 
-    context 'If the wallet is specified in config' do
+    context 'wallet is specified in config' do
       let(:config) { super().merge({ wallet: 'mywallet' }) }
       let(:server_url) { "#{config[:schema]}://#{config[:host]}:#{config[:port]}/wallet/#{config[:wallet]}" }
       it 'should have wallet name in the path like "/wallet/[wallet_name]"' do


### PR DESCRIPTION
TapyrusCoreClient is expected to send requests with `/wallet/[wallet_name]` path, when `config[:wallet]` is set.
However the current impl is not work as that. 
This PR is going to fix it.