### PR TITLE
Modified ASCII_8BIT to use ord when available

### DIFF
--- a/lib/tapyrus.rb
+++ b/lib/tapyrus.rb
@@ -119,10 +119,12 @@ module Tapyrus
     # get opcode
     def opcode
       case encoding
-      when Encoding::ASCII_8BIT
-        each_byte.next
-      when Encoding::US_ASCII
-        ord
+      when Encoding::ASCII_8BIT,Encoding::US_ASCII
+        begin
+          ord
+        rescue ArgumentError
+          each_byte.next
+        end
       else
         to_i
       end

--- a/lib/tapyrus.rb
+++ b/lib/tapyrus.rb
@@ -118,16 +118,7 @@ module Tapyrus
 
     # get opcode
     def opcode
-      case encoding
-      when Encoding::ASCII_8BIT,Encoding::US_ASCII
-        begin
-          ord
-        rescue ArgumentError
-          each_byte.next
-        end
-      else
-        to_i
-      end
+      force_encoding(Encoding::ASCII_8BIT).ord
     end
 
     def opcode?

--- a/spec/tapyrus_spec.rb
+++ b/spec/tapyrus_spec.rb
@@ -35,6 +35,17 @@ describe Tapyrus do
       expect(OP_PUSHDATA1.chr.opcode).to eq(OP_PUSHDATA1)
       expect('1446c2fbfbecc99a63148fa076de58cf29b0bcf0b0'.htb.opcode?).to be false
     end
+
+    context 'different character code' do
+      it 'should be return same opcode' do
+        expect(OP_1.chr.opcode).to eq(OP_1)
+        expect(OP_1.chr.force_encoding("US-ASCII").opcode).to eq(OP_1)
+        expect(OP_1.chr.force_encoding("UTF-8").opcode).to eq(OP_1)
+        expect(OP_SIZE.chr.opcode).to eq(OP_SIZE)
+        expect(OP_SIZE.chr.force_encoding("US-ASCII").opcode).to eq(OP_SIZE)
+        expect(OP_SIZE.chr.force_encoding("UTF-8").opcode).to eq(OP_SIZE)
+      end
+    end
   end
 
   describe '#pushed_data' do


### PR DESCRIPTION
When I ran `Tapyrus :: Tx.parse_from_payload (raw_tx.htb)` 100,000 times using stackprof, it took a long time to process String # opcode.
[run stackprof]
```
  irb > StackProf.run(mode: :cpu, interval: 10, raw: true, out: './gc-disable-each_byte-100000.dump') do
  irb >  GC.disable
  irb >  100000.times do ; Tapyrus::Tx.parse_from_payload(raw_tx.htb); end
  irb > end
  => #<File:./gc-disable-each_byte-100000.dump>
```
[result]
```
~/ $stackprof gc-disable-each_byte-100000.dump --text
==================================
  Mode: cpu(10)
  Samples: 3458655 (36.83% miss rate)
  GC: 0 (0.00%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
   3305392  (95.6%)     3305392  (95.6%)     String#opcode
   3371794  (97.5%)       44062   (1.3%)     Tapyrus::Script.parse_from_payload
     20872   (0.6%)       20872   (0.6%)     String#unpack
     18956   (0.5%)       18956   (0.5%)     Array#pack
   2696985  (78.0%)       12282   (0.4%)     Tapyrus::TxOut.parse_from_payload
```

When ASCII_8BIT, changing each_byte.next to ord made the processing speed faster.
```
# benchmark use this rawtransaction
raw_tx = "0100000002d52c333bd8f0216623ae12188abf66a53771ee07e16bad3836cc8be652137e2a090000006441b1876bef78fb841de3195a569c156be930184e4980dd27873ce36caa7a837caf171e0b8501fbff41bf83276360672e08b60e16b03543d6d1bdb23cd51ba8859c012102c538ad5caf12bdd7ee93b6ba8660500d211bd52c337ac0fda2df4b158c3e8be9ffffffffd52c333bd8f0216623ae12188abf66a53771ee07e16bad3836cc8be652137e2a1300000064412f07757b6430d6135e622fa7d0f8d70cf55ce37dd6cbd2a3cf42c88f81b0307f96e572262b8df0043746492cccc7162d6881d61260f174878b3448d251660ad4012102c538ad5caf12bdd7ee93b6ba8660500d211bd52c337ac0fda2df4b158c3e8be9ffffffff0401000000000000001976a9142bbb5fe7baa467a5b30fc91c00692c271fb2a4e988ac01000000000000003c21c123ef5e662f220c4e6449ea9c31efb2c5bfcb84b32fd5f3356b67d9d247b5240cbc76a9142bbb5fe7baa467a5b30fc91c00692c271fb2a4e988ac63000000000000001976a914c60892c7e8a0426fbe1654f1dc265b773d4afec888ac63000000000000003c21c123ef5e662f220c4e6449ea9c31efb2c5bfcb84b32fd5f3356b67d9d247b5240cbc76a914c60892c7e8a0426fbe1654f1dc265b773d4afec888ac00000000"
```
[each_byte.next]
```
  irb > Benchmark.bm do |x|
  irb >   x.report { 100000.times do ; Tapyrus::Tx.parse_from_payload(raw_tx.htb); end }
  irb > end
        user     system      total        real
    15.153893   1.672750  16.826643 ( 16.856641)
  => [#<Benchmark::Tms:0x00007fe46a160b60 @label="", @real=16.85664100000008, @cstime=0.0, @cutime=0.0, @stime=1.6727499999999997, @utime=15.153893, @total=16.826643>]
```
[ord]
```
~/ $stackprof gc-disable-use-ord-100000.dump --text
==================================
  Mode: cpu(10)
  Samples: 136087 (30.57% miss rate)
  GC: 0 (0.00%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
     51674  (38.0%)       37738  (27.7%)     Tapyrus::Script.parse_from_payload
     17414  (12.8%)       17414  (12.8%)     String#unpack
     17238  (12.7%)       17238  (12.7%)     Array#pack
     15427  (11.3%)       15427  (11.3%)     Tapyrus::TxOut#initialize
     67899  (49.9%)       13773  (10.1%)     Tapyrus::TxOut.parse_from_payload
      9718   (7.1%)        9513   (7.0%)     Tapyrus::Script#append_opcode
     41607  (30.6%)        9485   (7.0%)     Tapyrus::TxIn.parse_from_payload
    118844  (87.3%)        5187   (3.8%)     Tapyrus::Tx.parse_from_payload
      4720   (3.5%)        4720   (3.5%)     Tapyrus::Script#initialize
      6245   (4.6%)        2140   (1.6%)     Tapyrus::Util#unpack_var_int_from_io
```
```
  irb > Benchmark.bm do |x|
  irb >   x.report { 100000.times do ; Tapyrus::Tx.parse_from_payload(raw_tx.htb); end }
  irb > end
        user     system      total        real
    5.418707   0.015058   5.433765 (  5.447327)
  => [#<Benchmark::Tms:0x00007f8fe61aec08 @label="", @real=5.447327000000087, @cstime=0.0, @cutime=0.0, @stime=0.015058000000000016, @utime=5.418706999999998, @total=5.4337649999999975>]
```

So I changed it to use ord if it is available in ASCII_8BIT.