### PR TITLE
Raise ConnectionError for more clearly what happened.

### DIFF
--- a/lib/tapyrus/rpc/tapyrus_core_client.rb
+++ b/lib/tapyrus/rpc/tapyrus_core_client.rb
@@ -9,13 +9,7 @@ module Tapyrus
     # Almost case this exception happened from 401 Unauthorized or 500 Internal Server Error.
     # And also, throw by cause of other http's errors.
     #
-    # You can get raw response as cause, like as:
-    #
-    # rescue Tapyrus::RPC::Error => ex
-    #   ex.response
-    # end
-    #
-    # And, You can pull RPC error message when happened 500 Internal Server Error, like below:
+    # You can pull RPC error message when happened 500 Internal Server Error, like below:
     #
     # rescue Tapyrus::RPC::Error => ex
     #   if ex.message.response_code == 500
@@ -23,12 +17,10 @@ module Tapyrus
     #   end
     # end
     class Error < StandardError
-      attr_reader :response
       attr_reader :message
 
       def initialize(response)
         raise ArgumentError, "Must set response as cause." unless response
-        @response = response
 
         # set message from response body or status code.
         @message = {:response_code => response&.code, :response_msg => response&.msg}

--- a/lib/tapyrus/rpc/tapyrus_core_client.rb
+++ b/lib/tapyrus/rpc/tapyrus_core_client.rb
@@ -14,7 +14,7 @@ module Tapyrus
     # rescue TapyrusClientConnectionError => ex
     #   ex.response
     # end
-    class ConnectionError < StandardError
+    class Error < StandardError
       attr_reader :response
 
       def initialize(response)

--- a/lib/tapyrus/rpc/tapyrus_core_client.rb
+++ b/lib/tapyrus/rpc/tapyrus_core_client.rb
@@ -89,7 +89,7 @@ module Tapyrus
         request.content_type = 'application/json'
         request.body = data.to_json
         response = http.request(request)
-        raise ConnectionError.new(response) unless response.is_a? Net::HTTPOK
+        raise Error.new(response) unless response.is_a? Net::HTTPOK
         body = response.body
         response = Tapyrus::Ext::JsonParser.new(body.gsub(/\\u([\da-fA-F]{4})/) { [$1].pack('H*').unpack('n*').pack('U*').encode('ISO-8859-1').force_encoding('UTF-8') }).parse
         raise response['error'].to_json if response['error']

--- a/spec/tapyrus/rpc/tapyrus_core_client_spec.rb
+++ b/spec/tapyrus/rpc/tapyrus_core_client_spec.rb
@@ -55,6 +55,15 @@ describe Tapyrus::RPC::TapyrusCoreClient do
         client.rpc_command
       end
     end
+
+    context '401 unauthorized' do
+      it 'should return rpc response' do
+        stub_request(:post, server_url).to_return(
+            status: [401, "Unauthorized"]
+        )
+        expect {client.rpc_command}.to raise_error(Tapyrus::RPC::ConnectionError, 'Unauthorized')
+      end
+    end
   end
 
 end

--- a/spec/tapyrus/rpc/tapyrus_core_client_spec.rb
+++ b/spec/tapyrus/rpc/tapyrus_core_client_spec.rb
@@ -36,7 +36,7 @@ describe Tapyrus::RPC::TapyrusCoreClient do
         stub_request(:post, server_url).to_return(
           status: [500, "Internal Server Error"],
         )
-        expect { client.rpc_command }.to raise_error(Tapyrus::RPC::Error, "500 Internal Server Error")
+        expect { client.rpc_command }.to raise_error(Tapyrus::RPC::Error, {:response_code => "500", :response_msg => "Internal Server Error"}.to_s)
       end
     end
 
@@ -47,7 +47,7 @@ describe Tapyrus::RPC::TapyrusCoreClient do
           body: JSON.generate({ 'error': { 'code': '-1', 'message': 'RPC ERROR' } })
         )
         expect { client.rpc_command }.to raise_error do |e|
-          expect(e.message).to eq({"code"=>"-1", "message"=>"RPC ERROR"})
+          expect(e.message[:rpc_error]).to eq({"code"=>"-1", "message"=>"RPC ERROR"})
         end
       end
     end
@@ -75,7 +75,7 @@ describe Tapyrus::RPC::TapyrusCoreClient do
         stub_request(:post, server_url).to_return(
             status: [401, "Unauthorized"]
         )
-        expect {client.rpc_command}.to raise_error(Tapyrus::RPC::Error, '401 Unauthorized')
+        expect {client.rpc_command}.to raise_error(Tapyrus::RPC::Error, {:response_code => "401", :response_msg => "Unauthorized"}.to_s)
       end
     end
   end

--- a/spec/tapyrus/rpc/tapyrus_core_client_spec.rb
+++ b/spec/tapyrus/rpc/tapyrus_core_client_spec.rb
@@ -31,10 +31,24 @@ describe Tapyrus::RPC::TapyrusCoreClient do
       end
     end
 
-    context 'server responded with error' do
+    context '500 internal server error' do
       it 'should raise with response' do
-        stub_request(:post, server_url).to_return(body: JSON.generate({ 'error': { 'code': '-1', 'message': 'RPC ERROR' } }))
-        expect { client.rpc_command }.to raise_error(RuntimeError, '{"code":"-1","message":"RPC ERROR"}')
+        stub_request(:post, server_url).to_return(
+          status: [500, "Internal Server Error"],
+        )
+        expect { client.rpc_command }.to raise_error(Tapyrus::RPC::Error, "500 Internal Server Error")
+      end
+    end
+
+    context '500 internal error with error message' do
+      it 'should raise with response' do
+        stub_request(:post, server_url).to_return(
+          status: [500, "Internal Server Error"],
+          body: JSON.generate({ 'error': { 'code': '-1', 'message': 'RPC ERROR' } })
+        )
+        expect { client.rpc_command }.to raise_error do |e|
+          expect(e.message).to eq({"code"=>"-1", "message"=>"RPC ERROR"})
+        end
       end
     end
 
@@ -61,7 +75,7 @@ describe Tapyrus::RPC::TapyrusCoreClient do
         stub_request(:post, server_url).to_return(
             status: [401, "Unauthorized"]
         )
-        expect {client.rpc_command}.to raise_error(Tapyrus::RPC::ConnectionError, 'Unauthorized')
+        expect {client.rpc_command}.to raise_error(Tapyrus::RPC::Error, '401 Unauthorized')
       end
     end
   end


### PR DESCRIPTION
Currently, 'Tapyrus::RPC.client' throw JSONParseError when response is 401 Unauthorized.
It is a bit confused what happened. So that I implemented ConnectionError. It is raised when response is not 200 OK for cause to be more clearly that client could not connect RPC server.