### PR TITLE
add validate address method

### DIFF
--- a/lib/tapyrus/script/script.rb
+++ b/lib/tapyrus/script/script.rb
@@ -130,6 +130,12 @@ module Tapyrus
           Tapyrus::Script.to_p2pkh(hex)
         when Tapyrus.chain_params.p2sh_version
           Tapyrus::Script.to_p2sh(hex)
+        when Tapyrus.chain_params.cp2pkh_version
+          color = Tapyrus::Color::ColorIdentifier.nft(Tapyrus::OutPoint.new("01" * 32, 1))
+          Tapyrus::Script.to_cp2pkh(color, hex)
+        when Tapyrus.chain_params.cp2sh_version
+          color = Tapyrus::Color::ColorIdentifier.nft(Tapyrus::OutPoint.new("01" * 32, 1))
+          Tapyrus::Script.to_cp2sh(color, hex)
         else
           throw e
         end

--- a/lib/tapyrus/script/script.rb
+++ b/lib/tapyrus/script/script.rb
@@ -131,11 +131,11 @@ module Tapyrus
         when Tapyrus.chain_params.p2sh_version
           Tapyrus::Script.to_p2sh(hex)
         when Tapyrus.chain_params.cp2pkh_version
-          color = Tapyrus::Color::ColorIdentifier.nft(Tapyrus::OutPoint.new("01" * 32, 1))
-          Tapyrus::Script.to_cp2pkh(color, hex)
+          color = Tapyrus::Color::ColorIdentifier.parse_from_payload(hex[0..65].htb)
+          Tapyrus::Script.to_cp2pkh(color, hex[66..-1])
         when Tapyrus.chain_params.cp2sh_version
-          color = Tapyrus::Color::ColorIdentifier.nft(Tapyrus::OutPoint.new("01" * 32, 1))
-          Tapyrus::Script.to_cp2sh(color, hex)
+          color = Tapyrus::Color::ColorIdentifier.parse_from_payload(hex[0..65].htb)
+          Tapyrus::Script.to_cp2sh(color, hex[66..-1])
         else
           throw e
         end

--- a/lib/tapyrus/util.rb
+++ b/lib/tapyrus/util.rb
@@ -110,9 +110,12 @@ module Tapyrus
     # @return [Array] hex and address version
     def decode_base58_address(addr)
       hex = Base58.decode(addr)
-      if (hex.size == 50 || 116) && calc_checksum(hex[0...-8]) == hex[-8..-1]
-        raise 'Invalid version bytes.' unless [Tapyrus.chain_params.address_version, Tapyrus.chain_params.p2sh_version, Tapyrus.chain_params.cp2pkh_version, Tapyrus.chain_params.cp2sh_version].include?(hex[0..1])
+      if hex.size == 50 && calc_checksum(hex[0...-8]) == hex[-8..-1]
+        raise 'Invalid version bytes.' unless [Tapyrus.chain_params.address_version, Tapyrus.chain_params.p2sh_version].include?(hex[0..1])
         [hex[2...-8], hex[0..1]]
+      elsif hex.size == 116 && calc_checksum(hex[0...-8]) == hex[-8..-1]
+        raise 'Invalid version bytes.' unless [Tapyrus.chain_params.cp2pkh_version, Tapyrus.chain_params.cp2sh_version].include?(hex[0..1])
+        [hex[68...-8], hex[0..1]]
       else
         raise 'Invalid address.'
       end

--- a/lib/tapyrus/util.rb
+++ b/lib/tapyrus/util.rb
@@ -110,8 +110,8 @@ module Tapyrus
     # @return [Array] hex and address version
     def decode_base58_address(addr)
       hex = Base58.decode(addr)
-      if hex.size == 50 && calc_checksum(hex[0...-8]) == hex[-8..-1]
-        raise 'Invalid version bytes.' unless [Tapyrus.chain_params.address_version, Tapyrus.chain_params.p2sh_version].include?(hex[0..1])
+      if (hex.size == 50 || 116) && calc_checksum(hex[0...-8]) == hex[-8..-1]
+        raise 'Invalid version bytes.' unless [Tapyrus.chain_params.address_version, Tapyrus.chain_params.p2sh_version, Tapyrus.chain_params.cp2pkh_version, Tapyrus.chain_params.cp2sh_version].include?(hex[0..1])
         [hex[2...-8], hex[0..1]]
       else
         raise 'Invalid address.'
@@ -126,6 +126,18 @@ module Tapyrus
 
     def hmac_sha256(key, data)
       OpenSSL::HMAC.digest(DIGEST_NAME_SHA256, key, data)
+    end
+
+    # check whether +addr+ is valid address.
+    # @param [String] addr an address
+    # @return [Boolean] if valid address return true, otherwise false.
+    def valid_address?(addr)
+      begin
+        Tapyrus::Script.parse_from_addr(addr)
+        true
+      rescue Exception => e
+        false
+      end
     end
 
   end

--- a/lib/tapyrus/util.rb
+++ b/lib/tapyrus/util.rb
@@ -115,7 +115,7 @@ module Tapyrus
         [hex[2...-8], hex[0..1]]
       elsif hex.size == 116 && calc_checksum(hex[0...-8]) == hex[-8..-1]
         raise 'Invalid version bytes.' unless [Tapyrus.chain_params.cp2pkh_version, Tapyrus.chain_params.cp2sh_version].include?(hex[0..1])
-        [hex[68...-8], hex[0..1]]
+        [hex[2...-8], hex[0..1]]
       else
         raise 'Invalid address.'
       end

--- a/spec/tapyrus/script/script_spec.rb
+++ b/spec/tapyrus/script/script_spec.rb
@@ -534,7 +534,6 @@ describe Tapyrus::Script do
     end
 
     context 'dev' do
-      subject {Tapyrus::Script.to_cp2pkh(color, '46c2fbfbecc99a63148fa076de58cf29b0bcf0b0')}
       it 'should generate script' do
         # P2PKH
         expect(Tapyrus::Script.parse_from_addr('mmy7BEH1SUGAeSVUR22pt5hPaejo2645F1')).to eq(Tapyrus::Script.parse_from_payload('76a91446c2fbfbecc99a63148fa076de58cf29b0bcf0b088ac'.htb))

--- a/spec/tapyrus/script/script_spec.rb
+++ b/spec/tapyrus/script/script_spec.rb
@@ -519,21 +519,31 @@ describe Tapyrus::Script do
   end
 
   describe '#parse_from_addr' do
+    let(:color) { Tapyrus::Color::ColorIdentifier.nft(Tapyrus::OutPoint.new("01" * 32, 1))}
     context 'prod', network: :prod do
       it 'should generate script' do
         # P2PKH
         expect(Tapyrus::Script.parse_from_addr('191arn68nSLRiNJXD8srnmw4bRykBkVv6o')).to eq(Tapyrus::Script.parse_from_payload('76a91457dd450aed53d4e35d3555a24ae7dbf3e08a78ec88ac'.htb))
         # P2SH
         expect(Tapyrus::Script.parse_from_addr('3HG15Tn6hEd1WVR1ySQtWRstTbvyy6B5V8')).to eq(Tapyrus::Script.parse_from_payload('a914aac6e837af9eba6951552e83862740b069cf59f587'.htb))
+        # CP2PKH
+        expect(Tapyrus::Script.parse_from_addr('w26x2EaheVBsceNf9RufpmmZ1i1qLBux1UMKMs16dkcZxTP8FBRDXGQ3Cim71aJ1gtoFNttSPNfLsC')).to eq(Tapyrus::Script.parse_from_payload(Tapyrus::Script.to_cp2pkh(color, '46c2fbfbecc99a63148fa076de58cf29b0bcf0b0').to_payload))
+        # CP2SH
+        expect(Tapyrus::Script.parse_from_addr('4a28F5ZehQNaMsSCEzBGQSKjVx2Wz2c4s32joimPciFTLzc7AUqsfg2xhoBq8NAjEpRNFNUrAZrpEHB')).to eq(Tapyrus::Script.parse_from_payload(Tapyrus::Script.to_cp2sh(color, '7620a79e8657d066cff10e21228bf983cf546ac6').to_payload))
       end
     end
 
     context 'dev' do
+      subject {Tapyrus::Script.to_cp2pkh(color, '46c2fbfbecc99a63148fa076de58cf29b0bcf0b0')}
       it 'should generate script' do
         # P2PKH
         expect(Tapyrus::Script.parse_from_addr('mmy7BEH1SUGAeSVUR22pt5hPaejo2645F1')).to eq(Tapyrus::Script.parse_from_payload('76a91446c2fbfbecc99a63148fa076de58cf29b0bcf0b088ac'.htb))
         # P2SH
         expect(Tapyrus::Script.parse_from_addr('2N3wh1eYqMeqoLxuKFv8PBsYR4f8gYn8dHm')).to eq(Tapyrus::Script.parse_from_payload('a914755874542a017c665184c356f67c20cf4a0621ca87'.htb))
+        # CP2PKH
+        expect(Tapyrus::Script.parse_from_addr('22VdQ5VjWcF9zgsnPQodFBS1PBQPaAQEXSofkyMv2D9zV1MLp3JfScV6TMVaUQ42xeTfjieWssAaefMd')).to eq(Tapyrus::Script.parse_from_payload(Tapyrus::Script.to_cp2pkh(color, '46c2fbfbecc99a63148fa076de58cf29b0bcf0b0').to_payload))
+        # CP2SH
+        expect(Tapyrus::Script.parse_from_addr('2oLdn5UKgY7DayDDLL6LKfrNnHKp7iFK8zGAMHVGd2USnCxi3XmHdMBjrPdXXsoJUCn3R4J1RfbFP2aW')).to eq(Tapyrus::Script.parse_from_payload(Tapyrus::Script.to_cp2sh(color, '7620a79e8657d066cff10e21228bf983cf546ac6').to_payload))
       end
     end
 

--- a/spec/tapyrus/script/script_spec.rb
+++ b/spec/tapyrus/script/script_spec.rb
@@ -527,9 +527,9 @@ describe Tapyrus::Script do
         # P2SH
         expect(Tapyrus::Script.parse_from_addr('3HG15Tn6hEd1WVR1ySQtWRstTbvyy6B5V8')).to eq(Tapyrus::Script.parse_from_payload('a914aac6e837af9eba6951552e83862740b069cf59f587'.htb))
         # CP2PKH
-        expect(Tapyrus::Script.parse_from_addr('w26x2EaheVBsceNf9RufpmmZ1i1qLBux1UMKMs16dkcZxTP8FBRDXGQ3Cim71aJ1gtoFNttSPNfLsC')).to eq(Tapyrus::Script.parse_from_payload(Tapyrus::Script.to_cp2pkh(color, '46c2fbfbecc99a63148fa076de58cf29b0bcf0b0').to_payload))
+        expect(Tapyrus::Script.parse_from_addr('w26x2EaheVBsceNf9RufpmmZ1i1qLBux1UMKMs16dkcZxTP8FBRDXGQ3Cim71aJ1gtoFNttSPNfLsC')).to eq(Tapyrus::Script.to_cp2pkh(color, '46c2fbfbecc99a63148fa076de58cf29b0bcf0b0'))
         # CP2SH
-        expect(Tapyrus::Script.parse_from_addr('4a28F5ZehQNaMsSCEzBGQSKjVx2Wz2c4s32joimPciFTLzc7AUqsfg2xhoBq8NAjEpRNFNUrAZrpEHB')).to eq(Tapyrus::Script.parse_from_payload(Tapyrus::Script.to_cp2sh(color, '7620a79e8657d066cff10e21228bf983cf546ac6').to_payload))
+        expect(Tapyrus::Script.parse_from_addr('4a28F5ZehQNaMsSCEzBGQSKjVx2Wz2c4s32joimPciFTLzc7AUqsfg2xhoBq8NAjEpRNFNUrAZrpEHB')).to eq(Tapyrus::Script.to_cp2sh(color, '7620a79e8657d066cff10e21228bf983cf546ac6'))
       end
     end
 
@@ -540,9 +540,9 @@ describe Tapyrus::Script do
         # P2SH
         expect(Tapyrus::Script.parse_from_addr('2N3wh1eYqMeqoLxuKFv8PBsYR4f8gYn8dHm')).to eq(Tapyrus::Script.parse_from_payload('a914755874542a017c665184c356f67c20cf4a0621ca87'.htb))
         # CP2PKH
-        expect(Tapyrus::Script.parse_from_addr('22VdQ5VjWcF9zgsnPQodFBS1PBQPaAQEXSofkyMv2D9zV1MLp3JfScV6TMVaUQ42xeTfjieWssAaefMd')).to eq(Tapyrus::Script.parse_from_payload(Tapyrus::Script.to_cp2pkh(color, '46c2fbfbecc99a63148fa076de58cf29b0bcf0b0').to_payload))
+        expect(Tapyrus::Script.parse_from_addr('22VdQ5VjWcF9zgsnPQodFBS1PBQPaAQEXSofkyMv2D9zV1MLp3JfScV6TMVaUQ42xeTfjieWssAaefMd')).to eq(Tapyrus::Script.to_cp2pkh(color, '46c2fbfbecc99a63148fa076de58cf29b0bcf0b0'))
         # CP2SH
-        expect(Tapyrus::Script.parse_from_addr('2oLdn5UKgY7DayDDLL6LKfrNnHKp7iFK8zGAMHVGd2USnCxi3XmHdMBjrPdXXsoJUCn3R4J1RfbFP2aW')).to eq(Tapyrus::Script.parse_from_payload(Tapyrus::Script.to_cp2sh(color, '7620a79e8657d066cff10e21228bf983cf546ac6').to_payload))
+        expect(Tapyrus::Script.parse_from_addr('2oLdn5UKgY7DayDDLL6LKfrNnHKp7iFK8zGAMHVGd2USnCxi3XmHdMBjrPdXXsoJUCn3R4J1RfbFP2aW')).to eq(Tapyrus::Script.to_cp2sh(color, '7620a79e8657d066cff10e21228bf983cf546ac6'))
       end
     end
 

--- a/spec/tapyrus/util_spec.rb
+++ b/spec/tapyrus/util_spec.rb
@@ -105,7 +105,7 @@ describe Tapyrus::Util do
         util.decode_base58_address('22VdQ5VjWcF9zgsnPQodFBS1PBQPaAQEXSofkyMv2D9zV1MLp3JfScV6TMVaUQ42xeTfjieWssAaefMd')
       }
       it 'should be encoded' do
-        expect(subject[0]).to eq('46c2fbfbecc99a63148fa076de58cf29b0bcf0b0')
+        expect(subject[0]).to eq('c3ec2fd806701a3f55808cbec3922c38dafaa3070c48c803e9043ee3642c660b4646c2fbfbecc99a63148fa076de58cf29b0bcf0b0')
         expect(subject[1]).to eq('70')
       end
     end
@@ -115,7 +115,7 @@ describe Tapyrus::Util do
         util.decode_base58_address('2oLdn5UKgY7DayDDLL6LKfrNnHKp7iFK8zGAMHVGd2USnCxi3XmHdMBjrPdXXsoJUCn3R4J1RfbFP2aW')
       }
       it 'should be encoded' do
-        expect(subject[0]).to eq('7620a79e8657d066cff10e21228bf983cf546ac6')
+        expect(subject[0]).to eq('c3ec2fd806701a3f55808cbec3922c38dafaa3070c48c803e9043ee3642c660b467620a79e8657d066cff10e21228bf983cf546ac6')
         expect(subject[1]).to eq('c5')
       end
     end

--- a/spec/tapyrus/util_spec.rb
+++ b/spec/tapyrus/util_spec.rb
@@ -89,5 +89,38 @@ describe Tapyrus::Util do
     end
   end
 
+  describe '#valid_address?' do
+    context 'prod', network: :prod do
+      it 'should be true' do
+        # P2PKH
+        expect(util.valid_address?('191arn68nSLRiNJXD8srnmw4bRykBkVv6o')).to be true
+        # P2SH
+        expect(util.valid_address?('3HG15Tn6hEd1WVR1ySQtWRstTbvyy6B5V8')).to be true
+        # CP2PKH
+        expect(util.valid_address?('w26x2EaheVBsceNf9RufpmmZ1i1qLBux1UMKMs16dkcZxTP8FBRDXGQ3Cim71aJ1gtoFNttSPNfLsC')).to be true
+        # CP2SH
+        expect(util.valid_address?('4a28F5ZehQNaMsSCEzBGQSKjVx2Wz2c4s32joimPciFTLzc7AUqsfg2xhoBq8NAjEpRNFNUrAZrpEHB')).to be true
+
+        expect(util.valid_address?('mmy7BEH1SUGAeSVUR22pt5hPaejo2645F1')).to be false
+        expect(util.valid_address?('2N3wh1eYqMeqoLxuKFv8PBsYR4f8gYn8dHm')).to be false
+        expect(util.valid_address?('tb1qgmp0h7lvexdxx9y05pmdukx09xcteu9sx2h4ya')).to be false
+        expect(util.valid_address?('tb1q8nsuwycru4jyxrsv2ushyaee9yqyvvp2je60r4n6yjw06t88607sajrpy8')).to be false
+      end
+    end
+
+    context 'dev' do
+      it 'should be true' do
+        expect(util.valid_address?('mmy7BEH1SUGAeSVUR22pt5hPaejo2645F1')).to be true
+        expect(util.valid_address?('2N3wh1eYqMeqoLxuKFv8PBsYR4f8gYn8dHm')).to be true
+        expect(util.valid_address?('22VdQ5VjWcF9zgsnPQodFBS1PBQPaAQEXSofkyMv2D9zV1MLp3JfScV6TMVaUQ42xeTfjieWssAaefMd')).to be true
+        expect(util.valid_address?('2oLdn5UKgY7DayDDLL6LKfrNnHKp7iFK8zGAMHVGd2USnCxi3XmHdMBjrPdXXsoJUCn3R4J1RfbFP2aW')).to be true
+
+        expect(util.valid_address?('191arn68nSLRiNJXD8srnmw4bRykBkVv6o')).to be false
+        expect(util.valid_address?('3HG15Tn6hEd1WVR1ySQtWRstTbvyy6B5V8')).to be false
+        expect(util.valid_address?('bc1q2lw52zhd202wxhf42k3y4e7m70sg578ver73dn')).to be false
+        expect(util.valid_address?('bc1q8nsuwycru4jyxrsv2ushyaee9yqyvvp2je60r4n6yjw06t88607s264w7g')).to be false
+      end
+    end
+  end
 
 end

--- a/spec/tapyrus/util_spec.rb
+++ b/spec/tapyrus/util_spec.rb
@@ -80,12 +80,44 @@ describe Tapyrus::Util do
   end
 
   describe '#decode_base58_address' do
-    subject {
-      util.decode_base58_address('mmy7BEH1SUGAeSVUR22pt5hPaejo2645F1')
-    }
-    it 'should be encoded' do
-      expect(subject[0]).to eq('46c2fbfbecc99a63148fa076de58cf29b0bcf0b0')
-      expect(subject[1]).to eq('6f')
+    context 'p2pkh address' do
+      subject {
+        util.decode_base58_address('mmy7BEH1SUGAeSVUR22pt5hPaejo2645F1')
+      }
+      it 'should be encoded' do
+        expect(subject[0]).to eq('46c2fbfbecc99a63148fa076de58cf29b0bcf0b0')
+        expect(subject[1]).to eq('6f')
+      end
+    end
+
+    context 'p2sh address' do
+      subject {
+        util.decode_base58_address('2N3wh1eYqMeqoLxuKFv8PBsYR4f8gYn8dHm')
+      }
+      it 'should be encoded' do
+        expect(subject[0]).to eq('755874542a017c665184c356f67c20cf4a0621ca')
+        expect(subject[1]).to eq('c4')
+      end
+    end
+
+    context 'cp2pkh address' do
+      subject {
+        util.decode_base58_address('22VdQ5VjWcF9zgsnPQodFBS1PBQPaAQEXSofkyMv2D9zV1MLp3JfScV6TMVaUQ42xeTfjieWssAaefMd')
+      }
+      it 'should be encoded' do
+        expect(subject[0]).to eq('46c2fbfbecc99a63148fa076de58cf29b0bcf0b0')
+        expect(subject[1]).to eq('70')
+      end
+    end
+
+    context 'cp2sh address' do
+      subject {
+        util.decode_base58_address('2oLdn5UKgY7DayDDLL6LKfrNnHKp7iFK8zGAMHVGd2USnCxi3XmHdMBjrPdXXsoJUCn3R4J1RfbFP2aW')
+      }
+      it 'should be encoded' do
+        expect(subject[0]).to eq('7620a79e8657d066cff10e21228bf983cf546ac6')
+        expect(subject[1]).to eq('c5')
+      end
     end
   end
 
@@ -103,8 +135,8 @@ describe Tapyrus::Util do
 
         expect(util.valid_address?('mmy7BEH1SUGAeSVUR22pt5hPaejo2645F1')).to be false
         expect(util.valid_address?('2N3wh1eYqMeqoLxuKFv8PBsYR4f8gYn8dHm')).to be false
-        expect(util.valid_address?('tb1qgmp0h7lvexdxx9y05pmdukx09xcteu9sx2h4ya')).to be false
-        expect(util.valid_address?('tb1q8nsuwycru4jyxrsv2ushyaee9yqyvvp2je60r4n6yjw06t88607sajrpy8')).to be false
+        expect(util.valid_address?('22VdQ5VjWcF9zgsnPQodFBS1PBQPaAQEXSofkyMv2D9zV1MLp3JfScV6TMVaUQ42xeTfjieWssAaefMd')).to be false
+        expect(util.valid_address?('2oLdn5UKgY7DayDDLL6LKfrNnHKp7iFK8zGAMHVGd2USnCxi3XmHdMBjrPdXXsoJUCn3R4J1RfbFP2aW')).to be false
       end
     end
 
@@ -117,8 +149,8 @@ describe Tapyrus::Util do
 
         expect(util.valid_address?('191arn68nSLRiNJXD8srnmw4bRykBkVv6o')).to be false
         expect(util.valid_address?('3HG15Tn6hEd1WVR1ySQtWRstTbvyy6B5V8')).to be false
-        expect(util.valid_address?('bc1q2lw52zhd202wxhf42k3y4e7m70sg578ver73dn')).to be false
-        expect(util.valid_address?('bc1q8nsuwycru4jyxrsv2ushyaee9yqyvvp2je60r4n6yjw06t88607s264w7g')).to be false
+        expect(util.valid_address?('w26x2EaheVBsceNf9RufpmmZ1i1qLBux1UMKMs16dkcZxTP8FBRDXGQ3Cim71aJ1gtoFNttSPNfLsC')).to be false
+        expect(util.valid_address?('4a28F5ZehQNaMsSCEzBGQSKjVx2Wz2c4s32joimPciFTLzc7AUqsfg2xhoBq8NAjEpRNFNUrAZrpEHB')).to be false
       end
     end
   end


### PR DESCRIPTION
In this PR, I added the valid_address method.
In adding this method, we have changed the correspondence of CP2WPKH/CP2SH addresses to
address in the decode_base58_address and parse_from_addr methods.