### PR TITLE
Implement transaction builder

### DIFF
--- a/lib/tapyrus.rb
+++ b/lib/tapyrus.rb
@@ -49,6 +49,7 @@ module Tapyrus
   autoload :SLIP39, 'tapyrus/slip39'
   autoload :Color, 'tapyrus/script/color'
   autoload :Errors, 'tapyrus/errors'
+  autoload :TxBuilder, 'tapyrus/tx_builder'
 
   require_relative 'tapyrus/constants'
   require_relative 'tapyrus/ext/ecdsa'

--- a/lib/tapyrus/out_point.rb
+++ b/lib/tapyrus/out_point.rb
@@ -34,6 +34,10 @@ module Tapyrus
       index >= 0 && (!coinbase? && tx_hash != COINBASE_HASH)
     end
 
+    def ==(other)
+      to_payload == other&.to_payload
+    end
+
     # convert hash to txid
     def txid
       tx_hash.rhex

--- a/lib/tapyrus/script/color.rb
+++ b/lib/tapyrus/script/color.rb
@@ -24,6 +24,11 @@ module Tapyrus
         new(TokenTypes::NFT, Tapyrus.sha256(out_point.to_payload))
       end
 
+      # Return ColorIdentifier for native token(i.e TPC)
+      def self.default
+        new(TokenTypes::NONE, '0000000000000000000000000000000000000000000000000000000000000000'.htb)
+      end
+
       def to_payload
         [type, payload].pack('Ca*')
       end
@@ -49,6 +54,11 @@ module Tapyrus
 
       def eql?(other)
         to_payload.eql?(other.to_payload)
+      end
+
+      # Return true if the coin is native token(i.e TPC), otherwise false
+      def default?
+        self == ColorIdentifier.default
       end
 
       private

--- a/lib/tapyrus/tx_builder.rb
+++ b/lib/tapyrus/tx_builder.rb
@@ -1,4 +1,35 @@
 module Tapyrus
+  #
+  # Transaction Builder class.
+  #
+  # TxBuilder makes it easy to  build transactions without having to deal with TxOut/TxIn/Script directly.
+  #
+  # @example
+  #
+  #   txb = Tapyrus::TxBuilder.new
+  #   utxo1 = {
+  #     script_pubkey: Tapyrus::Script.parse_from_addr('mgCuyNQ1pUbKqL57tJQZX3hhUCaZcuX3RQ'),
+  #     txid: 'e1fb3255ead43dccd3ae0ac2c4f81b32260ca52749936a739669918bbb895411',
+  #     index: 0,
+  #     value: 3_000
+  #   }
+  #   color_id = Tapyrus::Color::ColorIdentifier.nft(...)
+  #   utxo2 = {
+  #     script_pubkey: Tapyrus::Script.parse_from_addr('mu9QMUcB9UCHbQjZJLAuyysQhM9tmFQbPx'),
+  #     color_id: color_id,
+  #     txid: 'e1fb3255ead43dccd3ae0ac2c4f81b32260ca52749936a739669918bbb895411',
+  #     index: 1,
+  #     value: 3_000
+  #   }
+  #
+  #   tx = txb
+  #     .add_utxo(utxo1)
+  #     .add_utxo(utxo2)
+  #     .data("0102030405060a0b0c")
+  #     .reissuable(utxo1[:script_pubkey],'n4jKJN5UMLsAejL1M5CTzQ8npeWoLBLCAH', 10_000)
+  #     .pay('n4jKJN5UMLsAejL1M5CTzQ8npeWoLBLCAH', 1_000)
+  #     .build
+  #
   class TxBuilder
     def initialize
       @utxos = []
@@ -8,7 +39,7 @@ module Tapyrus
     end
 
     # Add utxo for transaction input
-    # @param utxo
+    # @param utxo [Hash] a hash whose fields are `txid`, `index`, `script_pubkey`, `value`, and `color_id` (color_id is optional)
     def add_utxo(utxo)
       @utxos << utxo
       color_id = utxo[:color_id] || Tapyrus::Color::ColorIdentifier::default
@@ -18,21 +49,27 @@ module Tapyrus
     end
 
     # Issue reissuable token
+    # @param script_pubkey [Tapyrus::Script] the script pubkey in the issue input.
     # @param address [String] p2pkh or p2sh address.
+    # @param value [Integer] issued amount.
     def reissuable(script_pubkey, address, value)
       color_id = Tapyrus::Color::ColorIdentifier.reissuable(script_pubkey)
       pay(address, value, color_id)
     end
 
     # Issue non reissuable token
+    # @param out_point [Tapyrus::OutPoint] the out point at issue input.
     # @param address [String] p2pkh or p2sh address.
+    # @param value [Integer] issued amount.
     def non_reissuable(out_point, address, value)
       color_id = Tapyrus::Color::ColorIdentifier.non_reissuable(out_point)
       pay(address, value, color_id)
     end
 
     # Issue NFT
+    # @param out_point [Tapyrus::OutPoint] the out point at issue input.
     # @param address [String] p2pkh or p2sh address.
+    # @param value [Integer] issued amount.
     def nft(out_point, address)
       color_id = Tapyrus::Color::ColorIdentifier.nft(out_point)
       pay(address, 1, color_id)
@@ -40,8 +77,8 @@ module Tapyrus
 
     # Create payment output.
     # @param address [String] tapyrus address with Base58 format
-    # @param value [Integer]
-    # @param color_id [Tapyrus::Color::ColorIdentifier]
+    # @param value [Integer] issued or transferred amount
+    # @param color_id [Tapyrus::Color::ColorIdentifier] color id
     def pay(address, value, color_id = Tapyrus::Color::ColorIdentifier::default)
       script_pubkey = Tapyrus::Script.parse_from_addr(address)
 
@@ -74,10 +111,10 @@ module Tapyrus
       self
     end
 
-    # Set script_pubkey for change.
-    # If set, #build method add output for change which has the specified script_pubkey
+    # Set address for change.
+    # If set, #build method add output for change which has the specified address
     # If not set, transaction built by #build method has no output for change.
-    # @param script_pubkey [Tapyrus::Script] p2pkh or p2sh
+    # @param address [String] p2pkh or p2sh address.
     def change_script_pubkey(script_pubkey)
       raise ArgumentError, 'invalid address' if !script_pubkey.p2pkh? && !script_pubkey.p2sh?
       @change_script_pubkey = script_pubkey

--- a/lib/tapyrus/tx_builder.rb
+++ b/lib/tapyrus/tx_builder.rb
@@ -96,9 +96,7 @@ module Tapyrus
     # Create data output
     # @param contents [[String]] array of hex string
     def data(*contents)
-      payload = contents.inject('') do |payload, content|
-        payload << content
-      end
+      payload = contents.join
       script = Tapyrus::Script.new << Tapyrus::Script::OP_RETURN << payload
       @tx.outputs << Tapyrus::TxOut.new(script_pubkey: script)
       self
@@ -115,7 +113,8 @@ module Tapyrus
     # If set, #build method add output for change which has the specified address
     # If not set, transaction built by #build method has no output for change.
     # @param address [String] p2pkh or p2sh address.
-    def change_script_pubkey(script_pubkey)
+    def change_address(address)
+      script_pubkey = Tapyrus::Script.parse_from_addr(address)
       raise ArgumentError, 'invalid address' if !script_pubkey.p2pkh? && !script_pubkey.p2sh?
       @change_script_pubkey = script_pubkey
       self

--- a/lib/tapyrus/tx_builder.rb
+++ b/lib/tapyrus/tx_builder.rb
@@ -1,0 +1,119 @@
+module Tapyrus
+  class TxBuilder
+    def initialize
+      @utxos = []
+      @incomings = {}
+      @outgoings = {}
+      @tx = Tapyrus::Tx.new
+    end
+
+    # Add utxo for transaction input
+    # @param utxo
+    def add_utxo(utxo)
+      @utxos << utxo
+      color_id = utxo[:color_id] || Tapyrus::Color::ColorIdentifier::default
+      @incomings[color_id] ||= 0
+      @incomings[color_id] += utxo[:value]
+      self
+    end
+
+    # Issue reissuable token
+    # @param address [String] p2pkh or p2sh address.
+    def reissuable(script_pubkey, address, value)
+      color_id = Tapyrus::Color::ColorIdentifier.reissuable(script_pubkey)
+      pay(address, value, color_id)
+    end
+
+    # Issue non reissuable token
+    # @param address [String] p2pkh or p2sh address.
+    def non_reissuable(out_point, address, value)
+      color_id = Tapyrus::Color::ColorIdentifier.non_reissuable(out_point)
+      pay(address, value, color_id)
+    end
+
+    # Issue NFT
+    # @param address [String] p2pkh or p2sh address.
+    def nft(out_point, address)
+      color_id = Tapyrus::Color::ColorIdentifier.nft(out_point)
+      pay(address, 1, color_id)
+    end
+
+    # Create payment output.
+    # @param address [String] tapyrus address with Base58 format
+    # @param value [Integer]
+    # @param color_id [Tapyrus::Color::ColorIdentifier]
+    def pay(address, value, color_id = Tapyrus::Color::ColorIdentifier::default)
+      script_pubkey = Tapyrus::Script.parse_from_addr(address)
+
+      unless color_id.default?
+        raise ArgumentError, 'invalid address' if !script_pubkey.p2pkh? && !script_pubkey.p2sh?
+        script_pubkey = script_pubkey.add_color(color_id)
+      end
+
+      @outgoings[color_id] ||= 0
+      @outgoings[color_id] += value
+      @tx.outputs << Tapyrus::TxOut.new(script_pubkey: script_pubkey, value: value)
+      self
+    end
+
+    # Create data output
+    # @param contents [[String]] array of hex string
+    def data(*contents)
+      payload = contents.inject('') do |payload, content|
+        payload << content
+      end
+      script = Tapyrus::Script.new << Tapyrus::Script::OP_RETURN << payload
+      @tx.outputs << Tapyrus::TxOut.new(script_pubkey: script)
+      self
+    end
+
+    # Set transaction fee.
+    # @param fee [Integer] transaction fee
+    def fee(fee)
+      @fee = fee
+      self
+    end
+
+    # Set script_pubkey for change.
+    # If set, #build method add output for change which has the specified script_pubkey
+    # If not set, transaction built by #build method has no output for change.
+    # @param script_pubkey [Tapyrus::Script] p2pkh or p2sh
+    def change_script_pubkey(script_pubkey)
+      raise ArgumentError, 'invalid address' if !script_pubkey.p2pkh? && !script_pubkey.p2sh?
+      @change_script_pubkey = script_pubkey
+      self
+    end
+
+    # Build transaction
+    def build
+      expand_input
+      add_change if @change_script_pubkey
+      @tx
+    end
+
+    private
+
+    def add_change
+      @incomings.each do |color_id, in_amount|
+        out_amount = @outgoings[color_id] || 0
+        change, script_pubkey = if color_id.default?
+          [in_amount - out_amount - estimated_fee, @change_script_pubkey]
+        else
+          [in_amount - out_amount, @change_script_pubkey.add_color(color_id)]
+        end
+        @tx.outputs << Tapyrus::TxOut.new(script_pubkey: script_pubkey, value: change) if change > 0
+      end
+    end
+
+    def expand_input
+      @utxos.each do |utxo|
+        @tx.inputs << Tapyrus::TxIn.new(out_point: Tapyrus::OutPoint.from_txid(utxo[:txid], utxo[:index]))
+      end
+    end
+
+    # Return transaction fee
+    def estimated_fee
+      @fee
+    end
+  end
+end

--- a/spec/tapyrus/script/color_spec.rb
+++ b/spec/tapyrus/script/color_spec.rb
@@ -57,6 +57,13 @@ describe Tapyrus::Color::ColorIdentifier do
     it { expect(color1.hash).to eq color1_another_obj.hash }
     it { expect(color1.hash).not_to eq color2.hash }
   end
+
+  describe '#default?' do
+    let(:color_id) { Tapyrus::Color::ColorIdentifier.nft(Tapyrus::OutPoint.new("01" * 32, 1)) }
+
+    it { expect(color_id.default?).to be_falsy }
+    it { expect(Tapyrus::Color::ColorIdentifier.default.default?).to be_truthy }
+  end
 end
 
 describe 'Tapyrus::Color::ColoredOutput' do

--- a/spec/tapyrus/tx_builder_spec.rb
+++ b/spec/tapyrus/tx_builder_spec.rb
@@ -1,0 +1,196 @@
+require 'spec_helper'
+
+describe 'Tapyrus::TxBuilder' do
+  let(:txb) { Tapyrus::TxBuilder.new.fee(1_000) }
+  let(:p2pkh) { Tapyrus::Script.parse_from_payload('76a91492b7cc6e97407258428c23e1c936753ce41bbfbf88ac'.htb) }
+  let(:change_script_pubkey) { Tapyrus::Script.parse_from_payload('76a914078eb33618f15d0a1ce400f91074485d37dd987a88ac'.htb) }
+
+  let(:utxo1) do
+    {
+      script_pubkey: p2pkh,
+      txid: 'e1fb3255ead43dccd3ae0ac2c4f81b32260ca52749936a739669918bbb895411',
+      index: 0,
+      value: 3_000
+    }
+  end
+
+  let(:address) { 'n4jKJN5UMLsAejL1M5CTzQ8npeWoLBLCAH' }
+
+  describe '#add_utxo' do
+    subject(:tx) { txb.add_utxo(utxo1).build }
+
+    it { expect(tx.inputs.size).to eq 1 }
+    it { expect(tx.inputs[0].out_point).to eq Tapyrus::OutPoint.from_txid('e1fb3255ead43dccd3ae0ac2c4f81b32260ca52749936a739669918bbb895411', 0) }
+  end
+
+  describe '#reissuable' do
+    subject(:tx) do
+      txb
+        .add_utxo(utxo1)
+        .reissuable(utxo1[:script_pubkey], address, 10_000)
+        .change_script_pubkey(change_script_pubkey)
+        .build
+    end
+
+    it { expect(tx.outputs.size).to eq 2 }
+    # token output
+    it { expect(tx.outputs[0].value).to eq  10_000 }
+    it { expect(tx.outputs[0].script_pubkey.to_hex).to eq '21c1058f891e11dd6e67f8ea54f9bc80b7268313319572033d48218af91c5355c4f9bc76a914fea16b404e5c76d17e690ec08000eb55952c777988ac' }
+    # change output
+    it { expect(tx.outputs[1].value).to eq  2_000 }
+    it { expect(tx.outputs[1].script_pubkey).to eq change_script_pubkey }
+  end
+
+  describe '#non_reissuable' do
+    subject(:tx) do
+      out_point = Tapyrus::OutPoint.from_txid(utxo1[:txid], utxo1[:index])
+      txb
+        .add_utxo(utxo1)
+        .non_reissuable(out_point, address, 10_000)
+        .build
+    end
+
+    it { expect(tx.outputs.size).to eq 1 }
+    # token output
+    it { expect(tx.outputs[0].value).to eq  10_000 }
+    it { expect(tx.outputs[0].script_pubkey.to_hex).to eq '21c2beb3290e67a30ce8cb42b553d20d4adf2493285c88d8adcb8289bd27f575cd75bc76a914fea16b404e5c76d17e690ec08000eb55952c777988ac' }
+  end
+
+  describe '#nft' do
+    subject(:tx) do
+      out_point = Tapyrus::OutPoint.from_txid(utxo1[:txid], utxo1[:index])
+      txb
+        .add_utxo(utxo1)
+        .nft(out_point, address)
+        .build
+    end
+
+    it { expect(tx.outputs.size).to eq 1 }
+    # token output
+    it { expect(tx.outputs[0].value).to eq  1 }
+    it { expect(tx.outputs[0].script_pubkey.to_hex).to eq '21c3beb3290e67a30ce8cb42b553d20d4adf2493285c88d8adcb8289bd27f575cd75bc76a914fea16b404e5c76d17e690ec08000eb55952c777988ac' }
+  end
+
+  describe '#pay' do
+    context 'send tpc' do
+      subject(:tx) do
+        txb
+          .add_utxo(utxo1)
+          .change_script_pubkey(change_script_pubkey)
+          .pay(address, 1_000)
+          .build
+      end
+
+      it { expect(tx.inputs.size).to eq 1 }
+      it { expect(tx.outputs.size).to eq 2 }
+      # tpc output
+      it { expect(tx.outputs[0].value).to eq  1_000 }
+      it { expect(tx.outputs[0].script_pubkey.to_hex).to eq '76a914fea16b404e5c76d17e690ec08000eb55952c777988ac' }
+      # change output
+      it { expect(tx.outputs[1].value).to eq  1_000 }
+      it { expect(tx.outputs[1].script_pubkey.to_hex).to eq '76a914078eb33618f15d0a1ce400f91074485d37dd987a88ac' }
+    end
+
+    context 'send colored coin' do
+      subject(:tx) do
+        txb
+          .add_utxo(utxo1)
+          .add_utxo(utxo2)
+          .change_script_pubkey(change_script_pubkey)
+          .pay(address, 1_000, color_id)
+          .build
+      end
+
+      let(:out_point) { Tapyrus::OutPoint.from_txid(utxo1[:txid], utxo1[:index]) }
+      let(:color_id) { Tapyrus::Color::ColorIdentifier.nft(out_point) }
+      let(:utxo2) do
+        {
+          script_pubkey: Tapyrus::Script.parse_from_payload('76a9141654c4fcb23c1b50fa0270249eb6120a133cd32e88ac'.htb).add_color(color_id),
+          color_id: color_id,
+          txid: 'e1fb3255ead43dccd3ae0ac2c4f81b32260ca52749936a739669918bbb895411',
+          index: 0,
+          value: 3_000
+        }
+      end
+
+      it { expect(tx.inputs.size).to eq 2 }
+      it { expect(tx.outputs.size).to eq 3 }
+      # token output
+      it { expect(tx.outputs[0].value).to eq  1_000 }
+      it { expect(tx.outputs[0].script_pubkey.to_hex).to eq '21c3beb3290e67a30ce8cb42b553d20d4adf2493285c88d8adcb8289bd27f575cd75bc76a914fea16b404e5c76d17e690ec08000eb55952c777988ac' }
+      # change output
+      it { expect(tx.outputs[1].value).to eq  2_000 }
+      it { expect(tx.outputs[1].script_pubkey.to_hex).to eq '76a914078eb33618f15d0a1ce400f91074485d37dd987a88ac' }
+      # token change output
+      it { expect(tx.outputs[2].value).to eq  2_000 }
+      it { expect(tx.outputs[2].script_pubkey.to_hex).to eq '21c3beb3290e67a30ce8cb42b553d20d4adf2493285c88d8adcb8289bd27f575cd75bc76a914078eb33618f15d0a1ce400f91074485d37dd987a88ac' }
+    end
+  end
+
+  describe '#data' do
+    subject(:tx) { txb.data(content).build }
+
+    context 'data is hex' do
+      let(:content) { "0001" }
+
+      it { expect(tx.outputs.size).to eq 1 }
+      it { expect(tx.outputs[0].value).to eq  0 }
+      it { expect(tx.outputs[0].script_pubkey.to_hex).to eq  '6a020001' }
+    end
+
+    context 'data has multiple contents' do
+      subject(:tx) { txb.data("0001", "0002", "03").build }
+
+      it { expect(tx.outputs.size).to eq 1 }
+      it { expect(tx.outputs[0].value).to eq  0 }
+      it { expect(tx.outputs[0].script_pubkey.to_hex).to eq  '6a050001000203' }
+    end
+  end
+
+  describe '#change_script_pubkey' do
+    context 'if cp2pkh' do
+      subject { txb.change_script_pubkey(script) }
+
+      let(:script) { Tapyrus::Script.parse_from_payload('21c3beb3290e67a30ce8cb42b553d20d4adf2493285c88d8adcb8289bd27f575cd75bc76a914fea16b404e5c76d17e690ec08000eb55952c777988ac'.htb) }
+
+      it { expect { subject }.to raise_error(ArgumentError) }
+    end
+  end
+
+  describe '#build' do
+    context 'issue tokens, transfer tokens and push data' do
+      subject(:tx) do
+        txb
+          .add_utxo(utxo1)
+          .add_utxo(utxo2)
+          .reissuable(utxo1[:script_pubkey], address, 10_000)
+          .nft(Tapyrus::OutPoint.from_txid(utxo1[:txid], utxo1[:index]), address)
+          .pay(address, 1_000, color_id)
+          .data("01")
+          .build
+      end
+
+      let(:out_point) { Tapyrus::OutPoint.from_txid("0000000000000000000000000000000000000000000000000000000000000000", 0) }
+      let(:color_id) { Tapyrus::Color::ColorIdentifier.nft(out_point) }
+      let(:utxo2) do
+        {
+          script_pubkey: Tapyrus::Script.parse_from_payload('76a9141654c4fcb23c1b50fa0270249eb6120a133cd32e88ac'.htb).add_color(color_id),
+          color_id: color_id,
+          txid: 'e1fb3255ead43dccd3ae0ac2c4f81b32260ca52749936a739669918bbb895411',
+          index: 0,
+          value: 3_000
+        }
+      end
+
+      it { expect(tx.outputs.size).to eq 4 }
+      it { expect(tx.outputs[0].value).to eq 10_000 }
+      it { expect(tx.outputs[0].script_pubkey.to_hex).to eq '21c1058f891e11dd6e67f8ea54f9bc80b7268313319572033d48218af91c5355c4f9bc76a914fea16b404e5c76d17e690ec08000eb55952c777988ac' }
+      it { expect(tx.outputs[1].value).to eq 1 }
+      it { expect(tx.outputs[1].script_pubkey.to_hex).to eq '21c3beb3290e67a30ce8cb42b553d20d4adf2493285c88d8adcb8289bd27f575cd75bc76a914fea16b404e5c76d17e690ec08000eb55952c777988ac' }
+      it { expect(tx.outputs[2].value).to eq 1_000 }
+      it { expect(tx.outputs[2].script_pubkey.to_hex).to eq '21c36db65fd59fd356f6729140571b5bcd6bb3b83492a16e1bf0a3884442fc3c8a0ebc76a914fea16b404e5c76d17e690ec08000eb55952c777988ac' }
+      it { expect(tx.outputs[3].value).to eq 0 }
+      it { expect(tx.outputs[3].script_pubkey.to_hex).to eq '6a0101' }
+    end
+  end
+end

--- a/spec/tapyrus/tx_builder_spec.rb
+++ b/spec/tapyrus/tx_builder_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'Tapyrus::TxBuilder' do
   let(:txb) { Tapyrus::TxBuilder.new.fee(1_000) }
   let(:p2pkh) { Tapyrus::Script.parse_from_payload('76a91492b7cc6e97407258428c23e1c936753ce41bbfbf88ac'.htb) }
-  let(:change_script_pubkey) { Tapyrus::Script.parse_from_payload('76a914078eb33618f15d0a1ce400f91074485d37dd987a88ac'.htb) }
+  let(:change_address) { 'mgCuyNQ1pUbKqL57tJQZX3hhUCaZcuX3RQ' }
 
   let(:utxo1) do
     {
@@ -28,7 +28,7 @@ describe 'Tapyrus::TxBuilder' do
       txb
         .add_utxo(utxo1)
         .reissuable(utxo1[:script_pubkey], address, 10_000)
-        .change_script_pubkey(change_script_pubkey)
+        .change_address(change_address)
         .build
     end
 
@@ -38,7 +38,7 @@ describe 'Tapyrus::TxBuilder' do
     it { expect(tx.outputs[0].script_pubkey.to_hex).to eq '21c1058f891e11dd6e67f8ea54f9bc80b7268313319572033d48218af91c5355c4f9bc76a914fea16b404e5c76d17e690ec08000eb55952c777988ac' }
     # change output
     it { expect(tx.outputs[1].value).to eq  2_000 }
-    it { expect(tx.outputs[1].script_pubkey).to eq change_script_pubkey }
+    it { expect(tx.outputs[1].script_pubkey.to_hex).to eq '76a914078eb33618f15d0a1ce400f91074485d37dd987a88ac' }
   end
 
   describe '#non_reissuable' do
@@ -76,7 +76,7 @@ describe 'Tapyrus::TxBuilder' do
       subject(:tx) do
         txb
           .add_utxo(utxo1)
-          .change_script_pubkey(change_script_pubkey)
+          .change_address(change_address)
           .pay(address, 1_000)
           .build
       end
@@ -96,7 +96,7 @@ describe 'Tapyrus::TxBuilder' do
         txb
           .add_utxo(utxo1)
           .add_utxo(utxo2)
-          .change_script_pubkey(change_script_pubkey)
+          .change_address(change_address)
           .pay(address, 1_000, color_id)
           .build
       end
@@ -108,7 +108,7 @@ describe 'Tapyrus::TxBuilder' do
           script_pubkey: Tapyrus::Script.parse_from_payload('76a9141654c4fcb23c1b50fa0270249eb6120a133cd32e88ac'.htb).add_color(color_id),
           color_id: color_id,
           txid: 'e1fb3255ead43dccd3ae0ac2c4f81b32260ca52749936a739669918bbb895411',
-          index: 0,
+          index: 1,
           value: 3_000
         }
       end
@@ -147,11 +147,9 @@ describe 'Tapyrus::TxBuilder' do
     end
   end
 
-  describe '#change_script_pubkey' do
-    context 'if cp2pkh' do
-      subject { txb.change_script_pubkey(script) }
-
-      let(:script) { Tapyrus::Script.parse_from_payload('21c3beb3290e67a30ce8cb42b553d20d4adf2493285c88d8adcb8289bd27f575cd75bc76a914fea16b404e5c76d17e690ec08000eb55952c777988ac'.htb) }
+  describe '#change_address' do
+    context 'if cp2pkh address' do
+      subject { txb.change_address('22VZyRTDaMem4DcgBgRZgbo7PZm45gXSMWzHrYiYE9j1qVUYjiQPNdB25ke8eWnMS2styanta57D9PAT') }
 
       it { expect { subject }.to raise_error(ArgumentError) }
     end

--- a/spec/tapyrus/tx_builder_spec.rb
+++ b/spec/tapyrus/tx_builder_spec.rb
@@ -189,6 +189,19 @@ describe 'Tapyrus::TxBuilder' do
       it { expect(tx.outputs[2].script_pubkey.to_hex).to eq '21c36db65fd59fd356f6729140571b5bcd6bb3b83492a16e1bf0a3884442fc3c8a0ebc76a914fea16b404e5c76d17e690ec08000eb55952c777988ac' }
       it { expect(tx.outputs[3].value).to eq 0 }
       it { expect(tx.outputs[3].script_pubkey.to_hex).to eq '6a0101' }
+
+      context 'call twice' do
+        it 'should return same tx' do
+          txb
+            .add_utxo(utxo1)
+            .pay(address, 1_000, color_id)
+            .change_address(change_address)
+            .data("01")
+          one = txb.build.to_hex
+          another = txb.build.to_hex
+          expect(one).to eq another
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This PR implements Tapyrus::TxBuilder

TxBuilder improves the application code for building transactions because it allows you to build transactions without directly dealing with TxOut/TxIn/Script, etc.

```ruby
txb = Tapyrus::TxBuilder.new
utxo1 = {
    script_pubkey: xxx,
    txid: 'e1fb3255ead43dccd3ae0ac2c4f81b32260ca52749936a739669918bbb895411',
    index: 0,
    value: 3_000
}
color_id = Tapyrus::Color::ColorIdentifier.nft(...)
utxo2 = {
  script_pubkey: yyy,
  color_id: color_id,
  txid: 'e1fb3255ead43dccd3ae0ac2c4f81b32260ca52749936a739669918bbb895411',
  index: 1,
  value: 3_000
}

tx = txb
  .add_utxo(utxo1)
  .add_utxo(utxo2)
  .data("0102030405060a0b0c")
  .reissuable(utxo1[:script_pubkey],'n4jKJN5UMLsAejL1M5CTzQ8npeWoLBLCAH', 10_000)
  .pay('n4jKJN5UMLsAejL1M5CTzQ8npeWoLBLCAH', 1_000)
  .build

```