### PR TITLE
Make Tapyrus::RPC::Error possible to be used in outside of Tapyrus::RPC module

### DIFF
--- a/lib/tapyrus/rpc.rb
+++ b/lib/tapyrus/rpc.rb
@@ -3,5 +3,6 @@ module Tapyrus
     autoload :HttpServer, 'tapyrus/rpc/http_server'
     autoload :RequestHandler, 'tapyrus/rpc/request_handler'
     autoload :TapyrusCoreClient, 'tapyrus/rpc/tapyrus_core_client'
+    autoload :Error, 'tapyrus/rpc/tapyrus_core_client'
   end
 end


### PR DESCRIPTION
And also do below

Make Tapyrus::RPC::Error is created by error status information not response object
It is a bit difficult to create from response object in unit tests something.