### PR TITLE
Priv key for bip175

### DIFF
--- a/lib/tapyrus/bip175.rb
+++ b/lib/tapyrus/bip175.rb
@@ -55,6 +55,7 @@ module Tapyrus
 
     def priv_key
       key = master_ext_key.derive(PURPOSE_TYPE, true).derive(Tapyrus.chain_params.bip44_coin_type, true)
+
       # Split every 2 bytes
       paths = combined_hash.unpack('S>*')
       paths.inject(key) { |key, p| key.derive(p) }

--- a/lib/tapyrus/bip175.rb
+++ b/lib/tapyrus/bip175.rb
@@ -53,6 +53,8 @@ module Tapyrus
       Tapyrus.sha256(concatenated_hash)
     end
 
+    # Return pay-to-contract extended private key
+    # @return [Tapyrus::ExtKey] extended private key
     def priv_key
       key = master_ext_key.derive(PURPOSE_TYPE, true).derive(Tapyrus.chain_params.bip44_coin_type, true)
 

--- a/lib/tapyrus/rpc/request_handler.rb
+++ b/lib/tapyrus/rpc/request_handler.rb
@@ -47,32 +47,29 @@ module Tapyrus
 
       # Returns connected peer information.
       def getpeerinfo
-        node
-          .pool
-          .peers
-          .map do |peer|
-            local_addr = "#{peer.remote_version.remote_addr.ip}:18333"
-            {
-              id: peer.id,
-              addr: "#{peer.host}:#{peer.port}",
-              addrlocal: local_addr,
-              services: peer.remote_version.services.to_even_length_hex.rjust(16, '0'),
-              relaytxes: peer.remote_version.relay,
-              lastsend: peer.last_send,
-              lastrecv: peer.last_recv,
-              bytessent: peer.bytes_sent,
-              bytesrecv: peer.bytes_recv,
-              conntime: peer.conn_time,
-              pingtime: peer.ping_time,
-              minping: peer.min_ping,
-              version: peer.remote_version.version,
-              subver: peer.remote_version.user_agent,
-              inbound: !peer.outbound?,
-              startingheight: peer.remote_version.start_height,
-              best_hash: peer.best_hash,
-              best_height: peer.best_height
-            }
-          end
+        node.pool.peers.map do |peer|
+          local_addr = "#{peer.remote_version.remote_addr.ip}:18333"
+          {
+            id: peer.id,
+            addr: "#{peer.host}:#{peer.port}",
+            addrlocal: local_addr,
+            services: peer.remote_version.services.to_even_length_hex.rjust(16, '0'),
+            relaytxes: peer.remote_version.relay,
+            lastsend: peer.last_send,
+            lastrecv: peer.last_recv,
+            bytessent: peer.bytes_sent,
+            bytesrecv: peer.bytes_recv,
+            conntime: peer.conn_time,
+            pingtime: peer.ping_time,
+            minping: peer.min_ping,
+            version: peer.remote_version.version,
+            subver: peer.remote_version.user_agent,
+            inbound: !peer.outbound?,
+            startingheight: peer.remote_version.start_height,
+            best_hash: peer.best_hash,
+            best_height: peer.best_height
+          }
+        end
       end
 
       # broadcast transaction

--- a/lib/tapyrus/slip39/sss.rb
+++ b/lib/tapyrus/slip39/sss.rb
@@ -212,14 +212,10 @@ module Tapyrus
         l, r = ems[0...(ems.length / 2)].htb, ems[(ems.length / 2)..-1].htb
         salt = get_salt(id)
         e = (Tapyrus::SLIP39::BASE_ITERATION_COUNT << exp) / Tapyrus::SLIP39::ROUND_COUNT
-        Tapyrus::SLIP39::ROUND_COUNT
-          .times
-          .to_a
-          .reverse
-          .each do |i|
-            f = OpenSSL::PKCS5.pbkdf2_hmac((i.itb + passphrase), salt + r, e, r.bytesize, 'sha256')
-            l, r = padding_zero(r, r.bytesize), padding_zero((l.bti ^ f.bti).itb, r.bytesize)
-          end
+        Tapyrus::SLIP39::ROUND_COUNT.times.to_a.reverse.each do |i|
+          f = OpenSSL::PKCS5.pbkdf2_hmac((i.itb + passphrase), salt + r, e, r.bytesize, 'sha256')
+          l, r = padding_zero(r, r.bytesize), padding_zero((l.bti ^ f.bti).itb, r.bytesize)
+        end
         (r + l).bth
       end
 
@@ -234,13 +230,10 @@ module Tapyrus
         l, r = s[0...(s.bytesize / 2)], s[(s.bytesize / 2)..-1]
         salt = get_salt(id)
         e = (Tapyrus::SLIP39::BASE_ITERATION_COUNT << exp) / Tapyrus::SLIP39::ROUND_COUNT
-        Tapyrus::SLIP39::ROUND_COUNT
-          .times
-          .to_a
-          .each do |i|
-            f = OpenSSL::PKCS5.pbkdf2_hmac((i.itb + passphrase), salt + r, e, r.bytesize, 'sha256')
-            l, r = padding_zero(r, r.bytesize), padding_zero((l.bti ^ f.bti).itb, r.bytesize)
-          end
+        Tapyrus::SLIP39::ROUND_COUNT.times.to_a.each do |i|
+          f = OpenSSL::PKCS5.pbkdf2_hmac((i.itb + passphrase), salt + r, e, r.bytesize, 'sha256')
+          l, r = padding_zero(r, r.bytesize), padding_zero((l.bti ^ f.bti).itb, r.bytesize)
+        end
         (r + l).bth
       end
 

--- a/lib/tapyrus/version.rb
+++ b/lib/tapyrus/version.rb
@@ -1,3 +1,3 @@
 module Tapyrus
-  VERSION = '0.2.10'
+  VERSION = '0.2.11'
 end

--- a/spec/tapyrus/bip175_spec.rb
+++ b/spec/tapyrus/bip175_spec.rb
@@ -78,6 +78,18 @@ describe 'Tapyrus::BIP175' do
     it { is_expected.to eq '310057788c6073640dc222466d003411cd5c1cc0bf2803fc6ebbfae03ceb4451' }
   end
 
+  describe '#priv_key' do
+    subject { key.priv_key }
+
+    let(:key) { Tapyrus::BIP175.from_ext_key(master) }
+
+    it do
+      key << document1
+      key << document2
+      expect(subject.addr).to eq '1C7f322izqMqLzZzfzkPAjxBzprxDi47Yf'
+    end
+  end
+
   describe '#addr' do
     subject { key.addr }
 


### PR DESCRIPTION
This PR adds `#priv_key` method to Tapyrus::BIP175

This method will be needed to sign transaction which use outputs for Pay-to-contract transaction.