### PR TITLE
Add 'outputs' attribute to TxBuilder

### DIFF
--- a/lib/tapyrus/tx_builder.rb
+++ b/lib/tapyrus/tx_builder.rb
@@ -31,7 +31,7 @@ module Tapyrus
   #     .build
   #
   class TxBuilder
-    attr_reader :outputs
+    attr_reader :outputs, :utxos
 
     def initialize
       @utxos = []

--- a/lib/tapyrus/tx_builder.rb
+++ b/lib/tapyrus/tx_builder.rb
@@ -31,6 +31,8 @@ module Tapyrus
   #     .build
   #
   class TxBuilder
+    attr_reader :outputs
+
     def initialize
       @utxos = []
       @incomings = {}

--- a/lib/tapyrus/version.rb
+++ b/lib/tapyrus/version.rb
@@ -1,3 +1,3 @@
 module Tapyrus
-  VERSION = '0.2.11'
+  VERSION = '0.2.12'
 end


### PR DESCRIPTION
This PR adds `outputs` read-only attribute to TxBuilder class.