### PR TITLE
Use latest eventmachine for Apple Silicon

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,5 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'parallel_tests'
+
+gem 'eventmachine', git: 'https://github.com/eventmachine/eventmachine', branch: 'master'


### PR DESCRIPTION
Rspec execution fails for M1 Mac.

```
Unable to load the EventMachine C extension; To use the pure-ruby reactor, require 'em/pure_ruby'

An error occurred while loading ./spec/openassets/marker_output_spec.rb. - Did you mean?
                    rspec ./spec/openassets/util_spec.rb

Failure/Error: require 'eventmachine'

LoadError:
  dlopen(/Users/hajimeyamaguchi/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/eventmachine-1.2.7/lib/rubyeventmachine.bundle, 0x0009): symbol not found in flat namespace '_BIO_ctrl' - /Users/hajimeyamaguchi/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/eventmachine-1.2.7/lib/rubyeventmachine.bundle
# ./lib/tapyrus.rb:5:in `require'
# ./lib/tapyrus.rb:5:in `<top (required)>'
# ./spec/spec_helper.rb:2:in `require'
# ./spec/spec_helper.rb:2:in `<top (required)>'
# ./spec/openassets/marker_output_spec.rb:1:in `require'
# ./spec/openassets/marker_output_spec.rb:1:in `<top (required)>'
```

Eventmachine 1.2.7 does not support M1 mac now, but using master branch solves the problem.