### PR TITLE
Fix response of TapyrusCoreClient#message

### DIFF
--- a/lib/tapyrus/rpc/tapyrus_core_client.rb
+++ b/lib/tapyrus/rpc/tapyrus_core_client.rb
@@ -41,11 +41,11 @@ module Tapyrus
       # Return string that represents error message.
       # @return [String] error message
       def message
-        response.to_s
+        response.to_json
       end
 
       def to_s
-        message.to_s
+        message
       end
     end
 

--- a/lib/tapyrus/rpc/tapyrus_core_client.rb
+++ b/lib/tapyrus/rpc/tapyrus_core_client.rb
@@ -24,13 +24,24 @@ module Tapyrus
         @rpc_error = rpc_error
       end
 
-      def message
-        @message ||=
+      # Return response object as Hash
+      # @return [Hash] response
+      # @option response_code [Integer] HTTP status code
+      # @option response_msg [String] HTTP response body
+      # @option rpc_error [String] error message received from Tapyrus Core
+      def response
+        @response ||=
           begin
             m = { response_code: response_code, response_msg: response_msg }
             m.merge!(rpc_error: rpc_error) if rpc_error
             m
           end
+      end
+
+      # Return string that represents error message.
+      # @return [String] error message
+      def message
+        response.to_s
       end
 
       def to_s

--- a/lib/tapyrus/version.rb
+++ b/lib/tapyrus/version.rb
@@ -1,3 +1,3 @@
 module Tapyrus
-  VERSION = '0.2.12'
+  VERSION = '0.2.13'
 end

--- a/spec/tapyrus/rpc/tapyrus_core_client_spec.rb
+++ b/spec/tapyrus/rpc/tapyrus_core_client_spec.rb
@@ -39,7 +39,7 @@ describe Tapyrus::RPC::TapyrusCoreClient do
           body: JSON.generate({ 'error': { 'code': '-1', 'message': 'RPC ERROR' } })
         )
         expect { client.rpc_command }.to raise_error do |e|
-          expect(e.message[:rpc_error]).to eq({ 'code' => '-1', 'message' => 'RPC ERROR' })
+          expect(e.response[:rpc_error]).to eq({ 'code' => '-1', 'message' => 'RPC ERROR' })
         end
       end
     end

--- a/spec/tapyrus/rpc/tapyrus_core_client_spec.rb
+++ b/spec/tapyrus/rpc/tapyrus_core_client_spec.rb
@@ -27,7 +27,7 @@ describe Tapyrus::RPC::TapyrusCoreClient do
         stub_request(:post, server_url).to_return(status: [500, 'Internal Server Error'])
         expect { client.rpc_command }.to raise_error(
           Tapyrus::RPC::Error,
-          { response_code: '500', response_msg: 'Internal Server Error' }.to_s
+          { response_code: '500', response_msg: 'Internal Server Error' }.to_json
         )
       end
     end
@@ -40,6 +40,9 @@ describe Tapyrus::RPC::TapyrusCoreClient do
         )
         expect { client.rpc_command }.to raise_error do |e|
           expect(e.response[:rpc_error]).to eq({ 'code' => '-1', 'message' => 'RPC ERROR' })
+          expect(e.message).to eq(
+            "{\"response_code\":\"500\",\"response_msg\":\"Internal Server Error\",\"rpc_error\":{\"code\":\"-1\",\"message\":\"RPC ERROR\"}}"
+          )
         end
       end
     end
@@ -65,7 +68,7 @@ describe Tapyrus::RPC::TapyrusCoreClient do
         stub_request(:post, server_url).to_return(status: [401, 'Unauthorized'])
         expect { client.rpc_command }.to raise_error(
           Tapyrus::RPC::Error,
-          { response_code: '401', response_msg: 'Unauthorized' }.to_s
+          { response_code: '401', response_msg: 'Unauthorized' }.to_json
         )
       end
     end


### PR DESCRIPTION
This PR changes the return type of TapyrusCoreClient#message to String.
Exception class and its subclass should return a string message for #message method.
(https://docs.ruby-lang.org/en/3.1/Exception.html#method-i-message)