### PR TITLE
Add private key length check

### DIFF
--- a/lib/tapyrus/errors.rb
+++ b/lib/tapyrus/errors.rb
@@ -10,6 +10,7 @@ module Tapyrus
 
       INVALID_PRIV_KEY = 'Private key is not in range [1..n-1].'
       INVALID_CHECKSUM = 'Invalid checksum.'
+      INVALID_PRIV_LENGTH = 'Private key must be 32 bytes.'
     end
   end
 end

--- a/lib/tapyrus/key.rb
+++ b/lib/tapyrus/key.rb
@@ -41,7 +41,11 @@ module Tapyrus
       end
       @secp256k1_module = Tapyrus.secp_impl
       @priv_key = priv_key
-      raise ArgumentError, Errors::Messages::INVALID_PRIV_KEY unless validate_private_key_range(@priv_key) if @priv_key
+
+      if @priv_key
+        raise ArgumentError, Errors::Messages::INVALID_PRIV_KEY unless validate_private_key_range(@priv_key)
+        raise ArgumentError, Errors::Messages::INVALID_PRIV_LENGTH unless @priv_key.htb.bytesize == 32
+      end
       if pubkey
         @pubkey = pubkey
       else

--- a/spec/tapyrus/key_spec.rb
+++ b/spec/tapyrus/key_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Tapyrus::Key do
-
   describe '#from_wif' do
     context 'mainnet', network: :prod do
       subject { Tapyrus::Key.from_wif('KxJkzWsRQmr2bdU9TdWDFhXxg9nsELSEQojEQFZMFqJsHTBSXpP9') }
@@ -169,24 +168,27 @@ describe Tapyrus::Key do
   describe 'private key range check' do
     context 'on curve' do
       it 'not raise error' do
-        expect { Tapyrus::Key.new(
-          priv_key: '0000000000000000000000000000000000000000000000000000000000000001',
-          key_type: Tapyrus::Key::TYPES[:compressed]
-          ) }.not_to raise_error
+        expect {
+          Tapyrus::Key.new(
+            priv_key: '0000000000000000000000000000000000000000000000000000000000000001',
+            key_type: Tapyrus::Key::TYPES[:compressed]
+          )
+        }.not_to raise_error
         expect(
           Tapyrus::Key.new(
             priv_key: 'FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364140',
-            key_type: Tapyrus::Key::TYPES[:compressed])
-            .fully_valid_pubkey?
+            key_type: Tapyrus::Key::TYPES[:compressed]
+          ).fully_valid_pubkey?
         ).to be true
       end
     end
 
     context 'not on curve' do
       it 'raise error' do
-        expect {
-          Tapyrus::Key.new(priv_key: '00', key_type: Tapyrus::Key::TYPES[:compressed])
-        }.to raise_error(ArgumentError, Tapyrus::Errors::Messages::INVALID_PRIV_KEY)
+        expect { Tapyrus::Key.new(priv_key: '00', key_type: Tapyrus::Key::TYPES[:compressed]) }.to raise_error(
+          ArgumentError,
+          Tapyrus::Errors::Messages::INVALID_PRIV_KEY
+        )
         expect {
           Tapyrus::Key.new(
             priv_key: 'FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141',
@@ -198,10 +200,12 @@ describe Tapyrus::Key do
 
     context 'low-digit private key' do
       it do
-        expect{described_class.new(
-          priv_key: '6f3acb5b7ac66dacf87910bb0b04bed78284b9b50c0d061705a44447a947ff',
-          key_type: Tapyrus::Key::TYPES[:compressed]
-        )}.to raise_error(ArgumentError, Tapyrus::Errors::Messages::INVALID_PRIV_LENGTH)
+        expect {
+          described_class.new(
+            priv_key: '6f3acb5b7ac66dacf87910bb0b04bed78284b9b50c0d061705a44447a947ff',
+            key_type: Tapyrus::Key::TYPES[:compressed]
+          )
+        }.to raise_error(ArgumentError, Tapyrus::Errors::Messages::INVALID_PRIV_LENGTH)
       end
     end
   end

--- a/spec/tapyrus/key_spec.rb
+++ b/spec/tapyrus/key_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe Tapyrus::Key do
+
   describe '#from_wif' do
     context 'mainnet', network: :prod do
       subject { Tapyrus::Key.from_wif('KxJkzWsRQmr2bdU9TdWDFhXxg9nsELSEQojEQFZMFqJsHTBSXpP9') }
@@ -168,12 +169,14 @@ describe Tapyrus::Key do
   describe 'private key range check' do
     context 'on curve' do
       it 'not raise error' do
-        expect { Tapyrus::Key.new(priv_key: '01') }.not_to raise_error
-        expect {
-          Tapyrus::Key.new(priv_key: 'FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364140')
-        }.not_to raise_error
+        expect { Tapyrus::Key.new(
+          priv_key: '0000000000000000000000000000000000000000000000000000000000000001',
+          key_type: Tapyrus::Key::TYPES[:compressed]
+          ) }.not_to raise_error
         expect(
-          Tapyrus::Key.new(priv_key: 'FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364140')
+          Tapyrus::Key.new(
+            priv_key: 'FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364140',
+            key_type: Tapyrus::Key::TYPES[:compressed])
             .fully_valid_pubkey?
         ).to be true
       end
@@ -181,10 +184,24 @@ describe Tapyrus::Key do
 
     context 'not on curve' do
       it 'raise error' do
-        expect { Tapyrus::Key.new(priv_key: '00') }.to raise_error(ArgumentError)
         expect {
-          Tapyrus::Key.new(priv_key: 'FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141')
-        }.to raise_error(ArgumentError)
+          Tapyrus::Key.new(priv_key: '00', key_type: Tapyrus::Key::TYPES[:compressed])
+        }.to raise_error(ArgumentError, Tapyrus::Errors::Messages::INVALID_PRIV_KEY)
+        expect {
+          Tapyrus::Key.new(
+            priv_key: 'FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141',
+            key_type: Tapyrus::Key::TYPES[:compressed]
+          )
+        }.to raise_error(ArgumentError, Tapyrus::Errors::Messages::INVALID_PRIV_KEY)
+      end
+    end
+
+    context 'low-digit private key' do
+      it do
+        expect{described_class.new(
+          priv_key: '6f3acb5b7ac66dacf87910bb0b04bed78284b9b50c0d061705a44447a947ff',
+          key_type: Tapyrus::Key::TYPES[:compressed]
+        )}.to raise_error(ArgumentError, Tapyrus::Errors::Messages::INVALID_PRIV_LENGTH)
       end
     end
   end


### PR DESCRIPTION
Add private key length check to prevent wrong public key being derived in libsecp256k1.