### PR TITLE
Fix a bug where Key#generate with uncompressed key type

### DIFF
--- a/lib/tapyrus/key.rb
+++ b/lib/tapyrus/key.rb
@@ -56,7 +56,7 @@ module Tapyrus
 
     # generate key pair
     def self.generate(key_type = TYPES[:compressed])
-      priv_key, pubkey = Tapyrus.secp_impl.generate_key_pair
+      priv_key, pubkey = Tapyrus.secp_impl.generate_key_pair(compressed: key_type != TYPES[:uncompressed])
       new(priv_key: priv_key, pubkey: pubkey, key_type: key_type)
     end
 

--- a/spec/tapyrus/key_spec.rb
+++ b/spec/tapyrus/key_spec.rb
@@ -289,4 +289,25 @@ describe Tapyrus::Key do
       expect(found_small).to be true
     end
   end
+
+  describe "#generate" do
+    context "pure ruby" do
+      it "return decompressed public key" do
+        test_generate
+      end
+    end
+
+    context "libsecp256k1", use_secp256k1: true do
+      it "return decompressed public key" do
+        test_generate
+      end
+    end
+
+    def test_generate
+      compressed = Tapyrus::Key.generate(Tapyrus::Key::TYPES[:compressed])
+      expect(compressed.compressed?).to be true
+      uncompressed = Tapyrus::Key.generate(Tapyrus::Key::TYPES[:uncompressed])
+      expect(uncompressed.compressed?).to be false
+    end
+  end
 end


### PR DESCRIPTION
Even if I specified uncompressed when Key#generate, a Key object for the compressed public key was generated. Fix this issue.