### PR TITLE
feat: TIP-0174のPSTT(Partially Signed Tapyrus Transaction)を実装する

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Tapyrusrb supports following feature:
 - Key generation and verification for Schnorr and ECDSA (including [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) and [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) supports).
 - ECDSA signature(RFC6979 -Deterministic ECDSA, LOW-S, LOW-R support)
 - Schnorr signature
+- Partially Signed Tapyrus Transaction ([TIP-0174](https://github.com/chaintope/tips/blob/master/tip-0174.md))
 
 ## Requirements
 
@@ -78,6 +79,47 @@ Tapyrus.chain_params = :dev
 ```
 
 This parameter is described in https://github.com/chaintope/tapyrusrb/blob/master/lib/tapyrus/chainparams/dev.yml.
+
+### PSTT (Partially Signed Tapyrus Transaction)
+
+`Tapyrus::PSTT` implements the format [TIP-0174](https://github.com/chaintope/tips/blob/master/tip-0174.md) defines.
+Its methods follow the roles of the TIP: Creator, Constructor, Updater, Signer, Combiner, Input Finalizer and
+Transaction Extractor.
+
+```ruby
+# Creator
+pstt =
+  Tapyrus::PSTT::Tx.new(
+    inputs: [Tapyrus::PSTT::Input.new(out_point: out_point, utxo: prev_tx)],
+    outputs: [Tapyrus::PSTT::Output.new(amount: 99_000, script_pubkey: script_pubkey)]
+  )
+
+# Signer. The signature hash is computed from the fields of the PSTT.
+pstt.sign(0, key) # ECDSA. Pass algo: :schnorr for a Schnorr signature.
+
+# Input Finalizer and Transaction Extractor
+pstt.finalize!
+tx = pstt.extract_tx
+
+# For text transport
+Tapyrus::PSTT::Tx.from_base64(pstt.to_base64)
+```
+
+A PSTT which other parties will extend is created with `tx_modifiable`, so that a Constructor can add inputs and
+outputs afterwards. This is what a fee provider, which supplies the TPC that pays the fee of a Colored Coin
+transaction, needs:
+
+```ruby
+# The user leaves the inputs modifiable and signs with SIGHASH_ALL | SIGHASH_ANYONECANPAY.
+pstt = Tapyrus::PSTT::Tx.new(tx_modifiable: Tapyrus::PSTT::TxModifiable::INPUTS, inputs: inputs, outputs: outputs)
+pstt.sign(0, key, sighash_type: Tapyrus::SIGHASH_TYPE[:all] | Tapyrus::SIGHASH_TYPE[:anyonecanpay])
+
+# The fee provider verifies the amounts per color, then adds its TPC input and signs with SIGHASH_ALL.
+pstt.input_amounts # => { Tapyrus::Color::ColorIdentifier => amount }
+pstt.fee
+pstt.add_input(Tapyrus::PSTT::Input.new(out_point: fee_out_point, utxo: fee_tx))
+pstt.sign(1, provider_key)
+```
 
 ## Contributing
 

--- a/lib/tapyrus.rb
+++ b/lib/tapyrus.rb
@@ -52,6 +52,7 @@ module Tapyrus
   autoload :Contract, "tapyrus/contract"
   autoload :TIP0137, "tapyrus/tip0137"
   autoload :TIP0020, "tapyrus/tip0020"
+  autoload :PSTT, "tapyrus/pstt"
   autoload :JWS, "tapyrus/jws"
 
   require_relative "tapyrus/constants"

--- a/lib/tapyrus/key_path.rb
+++ b/lib/tapyrus/key_path.rb
@@ -3,20 +3,24 @@ module Tapyrus
     # key path convert an array of derive number
     # @param [String] path_string
     # @return [Array[Integer]] key path numbers.
+    # @raise [ArgumentError] if the path is not a sequence of decimal indexes, each optionally
+    #   followed by the hardened marker and each below Tapyrus::HARDENED_THRESHOLD.
     def parse_key_path(path_string)
-      path_string
-        .split("/")
-        .map
-        .with_index do |p, index|
-          if index == 0
-            raise ArgumentError.new("#{path_string} is invalid format.") unless p == "m"
-            next
-          end
-          raise ArgumentError.new("#{path_string} is invalid format.") unless p.delete("'") =~ /^[0-9]+$/
-          (p[-1] == "'" ? p.delete("'").to_i + Tapyrus::HARDENED_THRESHOLD : p.to_i)
-        end[
-        1..-1
-      ]
+      elements = path_string.split("/")
+      raise ArgumentError.new("#{path_string} is invalid format.") unless elements.first == "m"
+      elements[1..-1].map do |element|
+        hardened = element.end_with?("'")
+        # The index is validated before it is converted, since String#to_i stops at the first
+        # character which is not a digit and returns what it read so far. An element such as
+        # "1'2" would otherwise be taken for the index 1.
+        digits = hardened ? element[0..-2] : element
+        raise ArgumentError.new("#{path_string} is invalid format.") unless digits =~ /\A[0-9]+\z/
+        index = digits.to_i
+        # An index of Tapyrus::HARDENED_THRESHOLD or above is the hardened child of a smaller
+        # index, so it has no representation of its own in this notation.
+        raise ArgumentError.new("#{path_string} is invalid format.") if index >= Tapyrus::HARDENED_THRESHOLD
+        hardened ? index + Tapyrus::HARDENED_THRESHOLD : index
+      end
     end
 
     # key path numbers convert to path string.

--- a/lib/tapyrus/pstt.rb
+++ b/lib/tapyrus/pstt.rb
@@ -1,0 +1,326 @@
+module Tapyrus
+  # Partially Signed Tapyrus Transaction (PSTT) defined by TIP-0174.
+  #
+  # A PSTT holds a not-yet-signed Tapyrus transaction together with the metadata signers need.
+  # The data model follows BIP-370: the transaction is represented by per-input and per-output
+  # fields, so inputs and outputs can be added after creation.
+  module PSTT
+    autoload :Input, "tapyrus/pstt/input"
+    autoload :KeyOriginInfo, "tapyrus/pstt/key_origin_info"
+    autoload :Output, "tapyrus/pstt/output"
+    autoload :Proprietary, "tapyrus/pstt/proprietary"
+    autoload :Tx, "tapyrus/pstt/tx"
+
+    # The magic bytes which begin every PSTT. ASCII "pstt" followed by the separator 0xFF.
+    MAGIC = "70737474ff".htb
+
+    # The only version this TIP defines.
+    VERSION = 0
+
+    # The boundary between height-based and time-based locktime.
+    LOCKTIME_THRESHOLD = 500_000_000
+
+    # The sighash types TIP-0174 defines: SIGHASH_ALL, SIGHASH_NONE and SIGHASH_SINGLE, each
+    # optionally combined with SIGHASH_ANYONECANPAY.
+    SIGHASH_BASE_TYPES = [SIGHASH_TYPE[:all], SIGHASH_TYPE[:none], SIGHASH_TYPE[:single]].freeze
+    SIGHASH_TYPES = (SIGHASH_BASE_TYPES + SIGHASH_BASE_TYPES.map { |t| t | SIGHASH_TYPE[:anyonecanpay] }).freeze
+
+    # Global map key types.
+    module GlobalTypes
+      # Reserved. The global unsigned transaction of BIP-174 has no counterpart in this format.
+      UNSIGNED_TX = 0x00
+      XPUB = 0x01
+      TX_FEATURES = 0x02
+      FALLBACK_LOCKTIME = 0x03
+      INPUT_COUNT = 0x04
+      OUTPUT_COUNT = 0x05
+      TX_MODIFIABLE = 0x06
+      VERSION = 0xfb
+      PROPRIETARY = 0xfc
+    end
+
+    # Input map key types.
+    module InputTypes
+      UTXO = 0x00
+      PARTIAL_SIG = 0x02
+      SIGHASH_TYPE = 0x03
+      REDEEM_SCRIPT = 0x04
+      BIP32_DERIVATION = 0x06
+      FINAL_SCRIPTSIG = 0x07
+      RIPEMD160 = 0x0a
+      SHA256 = 0x0b
+      HASH160 = 0x0c
+      HASH256 = 0x0d
+      PREVIOUS_TXID = 0x0e
+      OUTPUT_INDEX = 0x0f
+      SEQUENCE = 0x10
+      REQUIRED_TIME_LOCKTIME = 0x11
+      REQUIRED_HEIGHT_LOCKTIME = 0x12
+      PROPRIETARY = 0xfc
+
+      # Segregated Witness(0x01, 0x05, 0x08, 0x09) and Taproot(0x13..0x18, defined by BIP-371)
+      # key types. They have no meaning in Tapyrus. Key types which BIPs later assigned to
+      # MuSig2 and other schemes are not listed here, so that they are carried through as
+      # unknown records rather than rejected.
+      RESERVED = [0x01, 0x05, 0x08, 0x09, *(0x13..0x18)].freeze
+    end
+
+    # Output map key types.
+    module OutputTypes
+      REDEEM_SCRIPT = 0x00
+      BIP32_DERIVATION = 0x02
+      AMOUNT = 0x03
+      SCRIPT = 0x04
+      PROPRIETARY = 0xfc
+
+      # Segregated Witness(0x01) and Taproot(0x05..0x07, defined by BIP-371) key types.
+      # They have no meaning in Tapyrus. See InputTypes::RESERVED.
+      RESERVED = [0x01, *(0x05..0x07)].freeze
+    end
+
+    # The bitfield of PSTT_GLOBAL_TX_MODIFIABLE.
+    module TxModifiable
+      INPUTS = 0x01
+      OUTPUTS = 0x02
+      HAS_SIGHASH_SINGLE = 0x04
+      ALL = INPUTS | OUTPUTS | HAS_SIGHASH_SINGLE
+    end
+
+    # Raised when a PSTT is malformed, or when an operation violates a rule of TIP-0174.
+    class Error < StandardError
+    end
+
+    # A single key-value record of a PSTT map.
+    KeyValue =
+      Struct.new(:type, :keydata, :value) do
+        # The complete key(<keytype> and <keydata>). Records are unique by this value within a map.
+        # @return [String] the complete key with binary format.
+        def key
+          Tapyrus.pack_var_int(type) + keydata
+        end
+
+        def to_payload
+          k = key
+          Tapyrus.pack_var_int(k.bytesize) + k + Tapyrus.pack_var_int(value.bytesize) + value
+        end
+      end
+
+    class << self
+      # Read a compact size unsigned integer from +buf+.
+      #
+      # Every compact size integer of the format must be minimally encoded. TIP-0174 states the
+      # requirement for <keytype>, and holding the whole container to it is what makes the byte
+      # representation of a PSTT unique: two encodings of the same length would otherwise produce
+      # two different byte strings carrying the same records. It also removes the need to treat
+      # the map separator specially, since a non-minimally encoded 0 is rejected here.
+      # @param [StringIO] buf a buffer.
+      # @return [Integer] the value.
+      # @raise [Tapyrus::PSTT::Error] if the buffer is truncated or the encoding is not minimal.
+      def read_compact_size(buf)
+        prefix = read_bytes(buf, 1).unpack1("C")
+        case prefix
+        when 0xfd
+          value = read_bytes(buf, 2).unpack1("v")
+          raise Error, "compact size is not minimally encoded." if value < 0xfd
+        when 0xfe
+          value = read_bytes(buf, 4).unpack1("V")
+          raise Error, "compact size is not minimally encoded." if value <= 0xffff
+        when 0xff
+          value = read_bytes(buf, 8).unpack1("Q<")
+          raise Error, "compact size is not minimally encoded." if value <= 0xffffffff
+        else
+          value = prefix
+        end
+        value
+      end
+
+      # Read exactly +size+ bytes from +buf+.
+      # @param [StringIO] buf a buffer.
+      # @param [Integer] size the byte size to be read.
+      # @return [String] the read data with binary format.
+      # @raise [Tapyrus::PSTT::Error] if the buffer holds fewer bytes.
+      def read_bytes(buf, size)
+        data = buf.read(size)
+        raise Error, "PSTT payload is truncated." if data.nil? || data.bytesize != size
+        data
+      end
+
+      # Parse a single map, which is a sequence of key-value records terminated by 0x00.
+      # @param [StringIO] buf a buffer.
+      # @return [Array[Tapyrus::PSTT::KeyValue]] the records of the map.
+      # @raise [Tapyrus::PSTT::Error] if the map is malformed.
+      def parse_map(buf)
+        records = []
+        keys = {}
+        loop do
+          raise Error, "PSTT map is not terminated." if buf.eof?
+          key_len = read_compact_size(buf)
+          break if key_len.zero? # the 0x00 separator
+          key = read_bytes(buf, key_len)
+          key_buf = StringIO.new(key)
+          type = read_compact_size(key_buf)
+          keydata = key_buf.read || ""
+          raise Error, "PSTT map contains a duplicated key." if keys.key?(key)
+          keys[key] = true
+          value_len = read_compact_size(buf)
+          records << KeyValue.new(type, keydata, read_bytes(buf, value_len))
+        end
+        records
+      end
+
+      # Serialize +records+ as a map.
+      # @param [Array[Tapyrus::PSTT::KeyValue]] records the records of the map.
+      # @param [Array[String]] order the complete keys of the map this PSTT was parsed from.
+      # @return [String] the serialized map with binary format.
+      def serialize_map(records, order = nil)
+        order_records(records, order).map(&:to_payload).join + "\x00".b
+      end
+
+      # Put +records+ back into the order the map was parsed in, so that parsing a PSTT and
+      # serializing it again yields the same bytes. TIP-0174 prescribes no order - either order is
+      # a valid PSTT carrying the same records - but a byte-stable round trip lets a caller hash,
+      # cache or diff a PSTT without normalizing it first. A record which was not in the parsed
+      # map, such as a signature collected since, follows the records which were, in the order
+      # this implementation generates them. A map which was not parsed is emitted in ascending
+      # order of the complete key.
+      # @param [Array[Tapyrus::PSTT::KeyValue]] records the records of the map.
+      # @param [Array[String]] order the complete keys of the map this PSTT was parsed from.
+      # @return [Array[Tapyrus::PSTT::KeyValue]] the ordered records.
+      def order_records(records, order)
+        return records.sort_by { |r| [r.type, r.keydata] } if order.nil? || order.empty?
+        rank = {}
+        order.each_with_index { |key, i| rank[key] ||= i }
+        records.each_with_index.sort_by { |record, i| [rank.fetch(record.key, order.size + i), i] }.map(&:first)
+      end
+
+      # Check that +record+ has no key data, as its field definition requires.
+      # @param [Tapyrus::PSTT::KeyValue] record a record.
+      # @raise [Tapyrus::PSTT::Error] if the record has key data.
+      def validate_empty_keydata!(record)
+        raise Error, format("keydata for type 0x%02x must be empty.", record.type) unless record.keydata.empty?
+      end
+
+      # Check that the key data of +record+ is a public key.
+      # @param [Tapyrus::PSTT::KeyValue] record a record.
+      # @raise [Tapyrus::PSTT::Error] if the key data is not a 33- or 65-byte public key.
+      def validate_pubkey_keydata!(record)
+        size = record.keydata.bytesize
+        unless [Tapyrus::Key::COMPRESSED_PUBLIC_KEY_SIZE, Tapyrus::Key::PUBLIC_KEY_SIZE].include?(size)
+          raise Error,
+                format("keydata for type 0x%02x must be a 33- or 65-byte public key, but %d bytes.", record.type, size)
+        end
+      end
+
+      # Check that the value of +record+ has +size+ bytes.
+      # @param [Tapyrus::PSTT::KeyValue] record a record.
+      # @param [Integer] size the required byte size.
+      # @raise [Tapyrus::PSTT::Error] if the value has another size.
+      def validate_value_size!(record, size)
+        unless record.value.bytesize == size
+          raise Error,
+                format(
+                  "value for type 0x%02x must be %d bytes, but %d bytes.",
+                  record.type,
+                  size,
+                  record.value.bytesize
+                )
+        end
+      end
+
+      # Read a 32-bit little endian unsigned integer from the value of +record+.
+      def read_u32(record)
+        validate_value_size!(record, 4)
+        record.value.unpack1("V")
+      end
+
+      # Read a 32-bit little endian signed integer from the value of +record+.
+      def read_i32(record)
+        validate_value_size!(record, 4)
+        record.value.unpack1("l<")
+      end
+
+      # Read a 64-bit little endian signed integer from the value of +record+.
+      def read_i64(record)
+        validate_value_size!(record, 8)
+        record.value.unpack1("q<")
+      end
+
+      # Read an 8-bit unsigned integer from the value of +record+.
+      def read_u8(record)
+        validate_value_size!(record, 1)
+        record.value.unpack1("C")
+      end
+
+      # Read a compact size unsigned integer from the value of +record+.
+      def read_count(record)
+        buf = StringIO.new(record.value)
+        count = read_compact_size(buf)
+        raise Error, format("value for type 0x%02x is not a compact size uint.", record.type) unless buf.eof?
+        count
+      end
+
+      # Parse the value or the key data of a record with +block+, and report any failure as a
+      # Tapyrus::PSTT::Error. The records of a PSTT come from another party, so a malformed one
+      # must not surface as an exception of the parser the field happens to be built on.
+      # @param [String] name the name of the field, used in the error message.
+      # @raise [Tapyrus::PSTT::Error] if the block raises.
+      def parse_field(name)
+        yield
+      rescue Error
+        raise
+      rescue StandardError => e
+        raise Error, "#{name} is malformed. #{e.message}"
+      end
+
+      # Check that +hash_type+ is one of the sighash types TIP-0174 defines.
+      # @param [Integer] hash_type a sighash type.
+      # @raise [Tapyrus::PSTT::Error] if it is not.
+      def validate_sighash_type!(hash_type)
+        unless SIGHASH_TYPES.include?(hash_type)
+          raise Error, format("Sighash type 0x%x is not defined by TIP-0174.", hash_type)
+        end
+      end
+
+      # Check that +amount+ is within the range Tapyrus allows.
+      # @param [Integer] amount an amount of tapy or of tokens.
+      # @raise [Tapyrus::PSTT::Error] if it is not.
+      def validate_amount!(amount)
+        unless amount.is_a?(Integer) && amount >= 0 && amount <= MAX_MONEY
+          raise Error, "PSTT_OUT_AMOUNT must be between 0 and #{MAX_MONEY}, but #{amount}."
+        end
+      end
+
+      # Check that +flags+ sets no reserved bit of PSTT_GLOBAL_TX_MODIFIABLE.
+      # @param [Integer] flags the bitfield.
+      # @raise [Tapyrus::PSTT::Error] if a reserved bit is set.
+      def validate_tx_modifiable!(flags)
+        unless (flags & ~TxModifiable::ALL).zero?
+          raise Error, "The reserved bits of PSTT_GLOBAL_TX_MODIFIABLE must be 0."
+        end
+      end
+
+      # Check that +version+ is a version this implementation supports.
+      # @param [Integer] version the value of PSTT_GLOBAL_VERSION.
+      # @raise [Tapyrus::PSTT::Error] if it is greater than the version TIP-0174 defines.
+      def validate_version!(version)
+        raise Error, "PSTT version #{version} is not supported." if version > VERSION
+      end
+
+      # Check that +value+ is a valid PSTT_IN_REQUIRED_TIME_LOCKTIME.
+      # @raise [Tapyrus::PSTT::Error] if it is below the threshold.
+      def validate_time_locktime!(value)
+        if value < LOCKTIME_THRESHOLD
+          raise Error, "PSTT_IN_REQUIRED_TIME_LOCKTIME must be greater than or equal to #{LOCKTIME_THRESHOLD}."
+        end
+      end
+
+      # Check that +value+ is a valid PSTT_IN_REQUIRED_HEIGHT_LOCKTIME.
+      # @raise [Tapyrus::PSTT::Error] if it is out of range.
+      def validate_height_locktime!(value)
+        if value.zero? || value >= LOCKTIME_THRESHOLD
+          raise Error, "PSTT_IN_REQUIRED_HEIGHT_LOCKTIME must be greater than 0 and less than #{LOCKTIME_THRESHOLD}."
+        end
+      end
+    end
+  end
+end

--- a/lib/tapyrus/pstt.rb
+++ b/lib/tapyrus/pstt.rb
@@ -290,6 +290,15 @@ module Tapyrus
         end
       end
 
+      # Check that +features+ is a positive value. Tapyrus currently defines only 1, but a
+      # transaction feature which a later version adds is accepted so that this implementation
+      # can carry it through.
+      # @param [Integer] features the value of PSTT_GLOBAL_TX_FEATURES.
+      # @raise [Tapyrus::PSTT::Error] if it is not positive.
+      def validate_features!(features)
+        raise Error, "PSTT_GLOBAL_TX_FEATURES must be greater than 0, but #{features}." unless features.positive?
+      end
+
       # Check that +flags+ sets no reserved bit of PSTT_GLOBAL_TX_MODIFIABLE.
       # @param [Integer] flags the bitfield.
       # @raise [Tapyrus::PSTT::Error] if a reserved bit is set.

--- a/lib/tapyrus/pstt/input.rb
+++ b/lib/tapyrus/pstt/input.rb
@@ -1,0 +1,422 @@
+module Tapyrus
+  module PSTT
+    # An input map of a PSTT.
+    class Input
+      # @!attribute [rw] out_point
+      #   @return [Tapyrus::OutPoint] PSTT_IN_PREVIOUS_TXID and PSTT_IN_OUTPUT_INDEX.
+      attr_accessor :out_point
+
+      # @!attribute [rw] utxo
+      #   @return [Tapyrus::Tx] the complete previous transaction which contains the output being spent.
+      attr_accessor :utxo
+
+      # @!attribute [rw] sighash_type
+      #   @return [Integer] the sighash type signers must use for this input.
+      attr_accessor :sighash_type
+
+      # @!attribute [rw] redeem_script
+      #   @return [Tapyrus::Script] the redeem script, if the output being spent is P2SH or CP2SH.
+      attr_accessor :redeem_script
+
+      # @!attribute [rw] final_script_sig
+      #   @return [Tapyrus::Script] the complete scriptSig for this input.
+      attr_accessor :final_script_sig
+
+      # @!attribute [rw] sequence
+      #   @return [Integer] the sequence number. nil means the default 0xFFFFFFFF.
+      attr_accessor :sequence
+
+      # @!attribute [rw] required_time_locktime
+      #   @return [Integer] the minimum Unix timestamp the transaction's locktime must be.
+      attr_accessor :required_time_locktime
+
+      # @!attribute [rw] required_height_locktime
+      #   @return [Integer] the minimum block height the transaction's locktime must be.
+      attr_accessor :required_height_locktime
+
+      # @!attribute [r] partial_sigs
+      #   @return [Hash] the signatures for this input, keyed by public key with hex format.
+      attr_reader :partial_sigs
+
+      # @!attribute [r] bip32_derivations
+      #   @return [Hash] Tapyrus::PSTT::KeyOriginInfo, keyed by public key with hex format.
+      attr_reader :bip32_derivations
+
+      # @!attribute [r] ripemd160_preimages
+      #   @return [Hash] the preimages, keyed by hash with hex format.
+      attr_reader :ripemd160_preimages
+
+      # @!attribute [r] sha256_preimages
+      #   @return [Hash] the preimages, keyed by hash with hex format.
+      attr_reader :sha256_preimages
+
+      # @!attribute [r] hash160_preimages
+      #   @return [Hash] the preimages, keyed by hash with hex format.
+      attr_reader :hash160_preimages
+
+      # @!attribute [r] hash256_preimages
+      #   @return [Hash] the preimages, keyed by hash with hex format.
+      attr_reader :hash256_preimages
+
+      # @!attribute [r] proprietaries
+      #   @return [Array[Tapyrus::PSTT::Proprietary]] the proprietary records.
+      attr_reader :proprietaries
+
+      # @!attribute [r] unknowns
+      #   @return [Hash] the records whose key type this implementation does not know, keyed by complete key.
+      attr_reader :unknowns
+
+      # @!attribute [rw] record_order
+      #   @return [Array[String]] the complete keys of the map this input was parsed from. See
+      #     Tapyrus::PSTT.order_records.
+      attr_accessor :record_order
+
+      # @param [Tapyrus::OutPoint] out_point the output being spent.
+      def initialize(out_point: nil, utxo: nil, sequence: nil)
+        @out_point = out_point
+        @utxo = utxo
+        @sequence = sequence
+        @partial_sigs = {}
+        @bip32_derivations = {}
+        @ripemd160_preimages = {}
+        @sha256_preimages = {}
+        @hash160_preimages = {}
+        @hash256_preimages = {}
+        @proprietaries = []
+        @unknowns = {}
+        @record_order = []
+      end
+
+      # Build an input map from the records of an input map.
+      # @param [Array[Tapyrus::PSTT::KeyValue]] records the records.
+      # @return [Tapyrus::PSTT::Input]
+      # @raise [Tapyrus::PSTT::Error] if a required field is missing or a field is malformed.
+      def self.parse_from_records(records)
+        input = new
+        txid = nil
+        index = nil
+        records.each do |record|
+          if InputTypes::RESERVED.include?(record.type)
+            raise Error, format("Input key type 0x%02x is reserved.", record.type)
+          end
+          case record.type
+          when InputTypes::UTXO
+            PSTT.validate_empty_keydata!(record)
+            input.utxo = parse_utxo(record.value)
+          when InputTypes::PARTIAL_SIG
+            PSTT.validate_pubkey_keydata!(record)
+            if record.value.empty?
+              raise Error, "PSTT_IN_PARTIAL_SIG must carry a signature followed by the 1-byte sighash type."
+            end
+            input.partial_sigs[record.keydata.bth] = record.value
+          when InputTypes::SIGHASH_TYPE
+            PSTT.validate_empty_keydata!(record)
+            input.sighash_type = PSTT.read_u32(record)
+            PSTT.validate_sighash_type!(input.sighash_type)
+          when InputTypes::REDEEM_SCRIPT
+            PSTT.validate_empty_keydata!(record)
+            input.redeem_script =
+              PSTT.parse_field("PSTT_IN_REDEEM_SCRIPT") { Tapyrus::Script.parse_from_payload(record.value) }
+          when InputTypes::BIP32_DERIVATION
+            PSTT.validate_pubkey_keydata!(record)
+            input.bip32_derivations[record.keydata.bth] = KeyOriginInfo.parse_from_payload(record.value)
+          when InputTypes::FINAL_SCRIPTSIG
+            PSTT.validate_empty_keydata!(record)
+            input.final_script_sig =
+              PSTT.parse_field("PSTT_IN_FINAL_SCRIPTSIG") { Tapyrus::Script.parse_from_payload(record.value) }
+          when InputTypes::RIPEMD160, InputTypes::HASH160
+            raise Error, "The preimage hash must be 20 bytes." unless record.keydata.bytesize == 20
+            input.preimages_for(record.type)[record.keydata.bth] = record.value
+          when InputTypes::SHA256, InputTypes::HASH256
+            raise Error, "The preimage hash must be 32 bytes." unless record.keydata.bytesize == 32
+            input.preimages_for(record.type)[record.keydata.bth] = record.value
+          when InputTypes::PREVIOUS_TXID
+            PSTT.validate_empty_keydata!(record)
+            PSTT.validate_value_size!(record, 32)
+            txid = record.value.bth
+          when InputTypes::OUTPUT_INDEX
+            PSTT.validate_empty_keydata!(record)
+            index = PSTT.read_u32(record)
+          when InputTypes::SEQUENCE
+            PSTT.validate_empty_keydata!(record)
+            input.sequence = PSTT.read_u32(record)
+          when InputTypes::REQUIRED_TIME_LOCKTIME
+            PSTT.validate_empty_keydata!(record)
+            input.required_time_locktime = PSTT.read_u32(record)
+            PSTT.validate_time_locktime!(input.required_time_locktime)
+          when InputTypes::REQUIRED_HEIGHT_LOCKTIME
+            PSTT.validate_empty_keydata!(record)
+            input.required_height_locktime = PSTT.read_u32(record)
+            PSTT.validate_height_locktime!(input.required_height_locktime)
+          when InputTypes::PROPRIETARY
+            input.proprietaries << Proprietary.parse_from_record(record)
+          else
+            input.unknowns[record.key] = record.value
+          end
+        end
+        raise Error, "PSTT_IN_PREVIOUS_TXID is required." unless txid
+        raise Error, "PSTT_IN_OUTPUT_INDEX is required." unless index
+        input.out_point = Tapyrus::OutPoint.new(txid, index)
+        input.record_order = records.map(&:key)
+        input.validate_sighash_type!
+        input
+      end
+
+      # Parse the value of a PSTT_IN_UTXO record.
+      # @param [String] payload the complete previous transaction with binary format.
+      # @return [Tapyrus::Tx]
+      # @raise [Tapyrus::PSTT::Error] if the value is not exactly one Tapyrus transaction.
+      def self.parse_utxo(payload)
+        utxo = PSTT.parse_field("PSTT_IN_UTXO") { Tapyrus::Tx.parse_from_payload(payload) }
+        # Tapyrus::Tx.parse_from_payload ignores trailing bytes. They would be lost when this
+        # input is serialized again, which a Combiner must not do.
+        raise Error, "PSTT_IN_UTXO has trailing bytes after the transaction." unless utxo.to_payload == payload
+        utxo
+      end
+      private_class_method :parse_utxo
+
+      # @return [Array[Tapyrus::PSTT::KeyValue]] the records of this input map.
+      def to_records
+        validate_sighash_type!
+        records = []
+        records << KeyValue.new(InputTypes::UTXO, "".b, utxo.to_payload) if utxo
+        partial_sigs.each { |pubkey, sig| records << KeyValue.new(InputTypes::PARTIAL_SIG, pubkey.htb, sig) }
+        records << KeyValue.new(InputTypes::SIGHASH_TYPE, "".b, [sighash_type].pack("V")) if sighash_type
+        records << KeyValue.new(InputTypes::REDEEM_SCRIPT, "".b, redeem_script.to_payload) if redeem_script
+        bip32_derivations.each do |pubkey, info|
+          records << KeyValue.new(InputTypes::BIP32_DERIVATION, pubkey.htb, info.to_payload)
+        end
+        records << KeyValue.new(InputTypes::FINAL_SCRIPTSIG, "".b, final_script_sig.to_payload) if final_script_sig
+        {
+          InputTypes::RIPEMD160 => ripemd160_preimages,
+          InputTypes::SHA256 => sha256_preimages,
+          InputTypes::HASH160 => hash160_preimages,
+          InputTypes::HASH256 => hash256_preimages
+        }.each { |type, preimages| preimages.each { |hash, image| records << KeyValue.new(type, hash.htb, image) } }
+        raise Error, "PSTT_IN_PREVIOUS_TXID is required." unless out_point
+        records << KeyValue.new(InputTypes::PREVIOUS_TXID, "".b, out_point.tx_hash.htb)
+        records << KeyValue.new(InputTypes::OUTPUT_INDEX, "".b, [out_point.index].pack("V"))
+        records << KeyValue.new(InputTypes::SEQUENCE, "".b, [sequence].pack("V")) if sequence
+        if required_time_locktime
+          PSTT.validate_time_locktime!(required_time_locktime)
+          records << KeyValue.new(InputTypes::REQUIRED_TIME_LOCKTIME, "".b, [required_time_locktime].pack("V"))
+        end
+        if required_height_locktime
+          PSTT.validate_height_locktime!(required_height_locktime)
+          records << KeyValue.new(InputTypes::REQUIRED_HEIGHT_LOCKTIME, "".b, [required_height_locktime].pack("V"))
+        end
+        proprietaries.each { |p| records << p.to_record(InputTypes::PROPRIETARY) }
+        unknowns.each { |key, value| records << unknown_record(key, value) }
+        records
+      end
+
+      def to_payload
+        PSTT.serialize_map(to_records, record_order)
+      end
+
+      # @return [Integer] the sequence number used in the transaction.
+      def final_sequence
+        sequence || Tapyrus::TxIn::SEQUENCE_FINAL
+      end
+
+      # @return [Tapyrus::TxOut] the output being spent, or nil if PSTT_IN_UTXO is absent.
+      def utxo_output
+        return nil unless utxo
+        utxo.outputs[out_point.index]
+      end
+
+      # @return [Boolean] whether this input has at least one signature.
+      def signed?
+        !partial_sigs.empty?
+      end
+
+      # @return [Boolean] whether this input has been finalized.
+      def finalized?
+        !final_script_sig.nil?
+      end
+
+      # The scriptCode used to compute the signature hash of this input.
+      # @return [Tapyrus::Script]
+      # @raise [Tapyrus::PSTT::Error] if the scriptCode cannot be determined.
+      def script_code
+        script = spent_script_pubkey
+        return script unless script.p2sh? || script.cp2sh?
+        raise Error, "PSTT_IN_REDEEM_SCRIPT is required to spend a P2SH or CP2SH output." unless redeem_script
+        validate_redeem_script!
+        redeem_script
+      end
+
+      # The scriptPubKey of the output being spent.
+      # @return [Tapyrus::Script]
+      # @raise [Tapyrus::PSTT::Error] if PSTT_IN_UTXO is absent or does not contain the output.
+      def spent_script_pubkey
+        validate_utxo!
+        utxo_output.script_pubkey
+      end
+
+      # Check that PSTT_IN_UTXO is present and identifies the output being spent.
+      # @raise [Tapyrus::PSTT::Error] if it is not.
+      def validate_utxo!
+        raise Error, "PSTT_IN_UTXO is required." unless utxo
+        raise Error, "The txid of PSTT_IN_UTXO does not match PSTT_IN_PREVIOUS_TXID." unless utxo.txid == out_point.txid
+        raise Error, "PSTT_IN_OUTPUT_INDEX does not exist in PSTT_IN_UTXO." unless utxo.outputs[out_point.index]
+      end
+
+      # Check that the redeem script hashes to the value committed in the scriptPubKey being spent.
+      # @raise [Tapyrus::PSTT::Error] if it does not.
+      def validate_redeem_script!
+        return unless redeem_script
+        script = spent_script_pubkey
+        committed =
+          if script.p2sh?
+            script.chunks[1].pushed_data
+          elsif script.cp2sh?
+            script.chunks[3].pushed_data
+          else
+            raise Error, "PSTT_IN_REDEEM_SCRIPT is set but the output being spent is neither P2SH nor CP2SH."
+          end
+        unless redeem_script.to_hash160 == committed.bth
+          raise Error, "PSTT_IN_REDEEM_SCRIPT does not hash to the value committed in the scriptPubKey."
+        end
+      end
+
+      # Check that this input requests a sighash type TIP-0174 defines, and that every signature
+      # it carries uses it. TIP-0174 obliges a Signer to use PSTT_IN_SIGHASH_TYPE, so an input
+      # which carries a signature made with another type contradicts itself: the signature covers
+      # a different transaction than the input asks for.
+      # @raise [Tapyrus::PSTT::Error] if a signature uses another sighash type.
+      def validate_sighash_type!
+        return unless sighash_type
+        PSTT.validate_sighash_type!(sighash_type)
+        partial_sigs.each do |pubkey, sig|
+          next if sig.empty?
+          hash_type = sig[-1].unpack1("C")
+          next if hash_type == sighash_type
+          raise Error,
+                format(
+                  "PSTT_IN_PARTIAL_SIG for %s uses sighash type 0x%x, but PSTT_IN_SIGHASH_TYPE requires 0x%x.",
+                  pubkey,
+                  hash_type,
+                  sighash_type
+                )
+        end
+      end
+
+      # Check everything a Signer must verify before signing this input.
+      # @raise [Tapyrus::PSTT::Error] if a check fails.
+      def validate_for_sign!
+        validate_utxo!
+        validate_redeem_script!
+        validate_sighash_type!
+      end
+
+      # Check that +algo+ does not conflict with the scheme of the signatures already collected.
+      # Tapyrus does not allow mixing ECDSA and Schnorr signatures within a single OP_CHECKMULTISIG.
+      # @param [Symbol] algo :ecdsa or :schnorr.
+      # @raise [Tapyrus::PSTT::Error] if the schemes conflict.
+      def validate_signature_algo!(algo)
+        return if partial_sigs.empty?
+        current = partial_sigs.values.first.bytesize == 65 ? :schnorr : :ecdsa
+        unless current == algo
+          raise Error, "This input already has #{current} signatures. #{algo} signatures must not be mixed."
+        end
+      end
+
+      # Whether the given signature commits to the sequence number of every input.
+      # A SIGHASH_ALL signature without SIGHASH_ANYONECANPAY does.
+      # @param [String] sig a signature with binary format.
+      # @return [Boolean]
+      def self.commits_to_all_sequences?(sig)
+        return false if sig.nil? || sig.empty?
+        hash_type = sig[-1].unpack1("C")
+        (hash_type & SIGHASH_TYPE[:anyonecanpay]).zero? && (hash_type & 0x1f) == SIGHASH_TYPE[:all]
+      end
+
+      # Assemble the complete scriptSig from the collected records and store it in PSTT_IN_FINAL_SCRIPTSIG.
+      # The records which are no longer needed are removed.
+      # @param [Hash] verified_sigs the signatures which verify against the transaction, keyed by
+      #   public key with hex format. Deciding that needs the whole transaction, which an input
+      #   map does not hold, so Tapyrus::PSTT::Tx#finalize! computes it and passes it here.
+      # @return [Tapyrus::PSTT::Input] self.
+      # @raise [Tapyrus::PSTT::Error] if the verified signatures do not satisfy the script being spent.
+      def finalize!(verified_sigs)
+        return self if finalized?
+        validate_for_sign!
+        self.final_script_sig = build_final_script_sig(verified_sigs)
+        partial_sigs.clear
+        bip32_derivations.clear
+        ripemd160_preimages.clear
+        sha256_preimages.clear
+        hash160_preimages.clear
+        hash256_preimages.clear
+        self.sighash_type = nil
+        self.redeem_script = nil
+        self
+      end
+
+      # @param [Integer] type a preimage key type.
+      # @return [Hash] the preimages of the type.
+      def preimages_for(type)
+        case type
+        when InputTypes::RIPEMD160
+          ripemd160_preimages
+        when InputTypes::SHA256
+          sha256_preimages
+        when InputTypes::HASH160
+          hash160_preimages
+        when InputTypes::HASH256
+          hash256_preimages
+        end
+      end
+
+      def ==(other)
+        other.is_a?(Input) && to_payload == other.to_payload
+      end
+
+      private
+
+      def unknown_record(key, value)
+        buf = StringIO.new(key)
+        type = PSTT.read_compact_size(buf)
+        KeyValue.new(type, buf.read || "".b, value)
+      end
+
+      # Build the complete scriptSig for the script being spent.
+      def build_final_script_sig(verified_sigs)
+        script = spent_script_pubkey
+        p2sh = script.p2sh? || script.cp2sh?
+        target = p2sh ? redeem_script : script
+        raise Error, "PSTT_IN_REDEEM_SCRIPT is required to finalize a P2SH or CP2SH input." if p2sh && !target
+        script_sig =
+          if target.p2pkh? || target.cp2pkh?
+            build_p2pkh_script_sig(target, verified_sigs)
+          elsif target.multisig?
+            build_multisig_script_sig(target, verified_sigs)
+          else
+            raise Error, "Unsupported script type. The scriptSig must be assembled by the application."
+          end
+        script_sig << redeem_script.to_payload if p2sh
+        script_sig
+      end
+
+      def build_p2pkh_script_sig(target, verified_sigs)
+        pubkey_hash = target.chunks[target.cp2pkh? ? 4 : 2].pushed_data.bth
+        pubkey, sig = verified_sigs.find { |key, _| Tapyrus.hash160(key) == pubkey_hash }
+        raise Error, "No valid signature for the public key committed in the scriptPubKey." unless sig
+        Tapyrus::Script.new << sig << pubkey.htb
+      end
+
+      def build_multisig_script_sig(target, verified_sigs)
+        threshold = Tapyrus::Opcodes.opcode_to_small_int(target.chunks[0].opcode)
+        sigs = target.get_multisig_pubkeys.map { |pubkey| verified_sigs[pubkey.bth] }.compact
+        if sigs.size < threshold
+          raise Error, "#{threshold} signatures are required, but only #{sigs.size} of the collected ones are valid."
+        end
+        # OP_0 is the dummy element OP_CHECKMULTISIG pops off the stack.
+        script_sig = Tapyrus::Script.new << Tapyrus::Opcodes::OP_0
+        sigs.take(threshold).each { |sig| script_sig << sig }
+        script_sig
+      end
+    end
+  end
+end

--- a/lib/tapyrus/pstt/key_origin_info.rb
+++ b/lib/tapyrus/pstt/key_origin_info.rb
@@ -17,6 +17,12 @@ module Tapyrus
       # @param [Array[Integer]] key_paths the derivation path.
       def initialize(fingerprint:, key_paths: [])
         raise Error, "fingerprint must be 4 bytes." unless fingerprint.htb.bytesize == 4
+        # Each element occupies 4 bytes of the record. Array#pack truncates a larger value to its
+        # lowest 32 bits without raising, which would turn a path this object was built with into
+        # a different one once it is serialized.
+        unless key_paths.all? { |index| index.is_a?(Integer) && index >= 0 && index <= 0xffffffff }
+          raise Error, "Each derivation path element must be a 32-bit unsigned integer."
+        end
         @fingerprint = fingerprint
         @key_paths = key_paths
       end

--- a/lib/tapyrus/pstt/key_origin_info.rb
+++ b/lib/tapyrus/pstt/key_origin_info.rb
@@ -1,0 +1,57 @@
+module Tapyrus
+  module PSTT
+    # The value of a BIP 32 derivation record: a master key fingerprint followed by a derivation path.
+    class KeyOriginInfo
+      include Tapyrus::KeyPath
+      extend Tapyrus::KeyPath
+
+      # @!attribute [r] fingerprint
+      #   @return [String] the master key fingerprint with hex format.
+      attr_reader :fingerprint
+
+      # @!attribute [r] key_paths
+      #   @return [Array[Integer]] the derivation path as a sequence of 32-bit unsigned integers.
+      attr_reader :key_paths
+
+      # @param [String] fingerprint the master key fingerprint with hex format.
+      # @param [Array[Integer]] key_paths the derivation path.
+      def initialize(fingerprint:, key_paths: [])
+        raise Error, "fingerprint must be 4 bytes." unless fingerprint.htb.bytesize == 4
+        @fingerprint = fingerprint
+        @key_paths = key_paths
+      end
+
+      # Parse the value of a BIP 32 derivation record.
+      # @param [String] payload the value with binary format.
+      # @return [Tapyrus::PSTT::KeyOriginInfo]
+      def self.parse_from_payload(payload)
+        if payload.bytesize < 4 || ((payload.bytesize - 4) % 4) != 0
+          raise Error, "BIP 32 derivation value must be a 4-byte fingerprint followed by 32-bit path elements."
+        end
+        fingerprint, *key_paths = payload.unpack("H8V*")
+        new(fingerprint: fingerprint, key_paths: key_paths)
+      end
+
+      # Build from a derivation path string such as "m/44'/2377'/0'/0/0".
+      # @param [String] fingerprint the master key fingerprint with hex format.
+      # @param [String] path the derivation path string.
+      # @return [Tapyrus::PSTT::KeyOriginInfo]
+      def self.from_path(fingerprint, path)
+        new(fingerprint: fingerprint, key_paths: parse_key_path(path))
+      end
+
+      def to_payload
+        fingerprint.htb + key_paths.pack("V*")
+      end
+
+      # @return [String] the derivation path string.
+      def path
+        to_key_path(key_paths)
+      end
+
+      def ==(other)
+        other.is_a?(KeyOriginInfo) && to_payload == other.to_payload
+      end
+    end
+  end
+end

--- a/lib/tapyrus/pstt/output.rb
+++ b/lib/tapyrus/pstt/output.rb
@@ -1,0 +1,129 @@
+module Tapyrus
+  module PSTT
+    # An output map of a PSTT.
+    class Output
+      # @!attribute [rw] amount
+      #   @return [Integer] the amount of this output. Tokens for a colored output, otherwise tapy.
+      attr_accessor :amount
+
+      # @!attribute [rw] script_pubkey
+      #   @return [Tapyrus::Script] the scriptPubKey of this output.
+      attr_accessor :script_pubkey
+
+      # @!attribute [rw] redeem_script
+      #   @return [Tapyrus::Script] the redeem script, if this output is P2SH or CP2SH.
+      attr_accessor :redeem_script
+
+      # @!attribute [r] bip32_derivations
+      #   @return [Hash] Tapyrus::PSTT::KeyOriginInfo, keyed by public key with hex format.
+      attr_reader :bip32_derivations
+
+      # @!attribute [r] proprietaries
+      #   @return [Array[Tapyrus::PSTT::Proprietary]] the proprietary records.
+      attr_reader :proprietaries
+
+      # @!attribute [r] unknowns
+      #   @return [Hash] the records whose key type this implementation does not know, keyed by complete key.
+      attr_reader :unknowns
+
+      # @!attribute [rw] record_order
+      #   @return [Array[String]] the complete keys of the map this output was parsed from. See
+      #     Tapyrus::PSTT.order_records.
+      attr_accessor :record_order
+
+      def initialize(amount: nil, script_pubkey: nil, redeem_script: nil)
+        @amount = amount
+        @script_pubkey = script_pubkey
+        @redeem_script = redeem_script
+        @bip32_derivations = {}
+        @proprietaries = []
+        @unknowns = {}
+        @record_order = []
+      end
+
+      # Build an output map from the records of an output map.
+      # @param [Array[Tapyrus::PSTT::KeyValue]] records the records.
+      # @return [Tapyrus::PSTT::Output]
+      # @raise [Tapyrus::PSTT::Error] if a required field is missing or a field is malformed.
+      def self.parse_from_records(records)
+        output = new
+        records.each do |record|
+          if OutputTypes::RESERVED.include?(record.type)
+            raise Error, format("Output key type 0x%02x is reserved.", record.type)
+          end
+          case record.type
+          when OutputTypes::REDEEM_SCRIPT
+            PSTT.validate_empty_keydata!(record)
+            output.redeem_script =
+              PSTT.parse_field("PSTT_OUT_REDEEM_SCRIPT") { Tapyrus::Script.parse_from_payload(record.value) }
+          when OutputTypes::BIP32_DERIVATION
+            PSTT.validate_pubkey_keydata!(record)
+            output.bip32_derivations[record.keydata.bth] = KeyOriginInfo.parse_from_payload(record.value)
+          when OutputTypes::AMOUNT
+            PSTT.validate_empty_keydata!(record)
+            output.amount = PSTT.read_i64(record)
+            PSTT.validate_amount!(output.amount)
+          when OutputTypes::SCRIPT
+            PSTT.validate_empty_keydata!(record)
+            output.script_pubkey =
+              PSTT.parse_field("PSTT_OUT_SCRIPT") { Tapyrus::Script.parse_from_payload(record.value) }
+          when OutputTypes::PROPRIETARY
+            output.proprietaries << Proprietary.parse_from_record(record)
+          else
+            output.unknowns[record.key] = record.value
+          end
+        end
+        raise Error, "PSTT_OUT_AMOUNT is required." unless output.amount
+        raise Error, "PSTT_OUT_SCRIPT is required." unless output.script_pubkey
+        output.record_order = records.map(&:key)
+        output
+      end
+
+      # @return [Array[Tapyrus::PSTT::KeyValue]] the records of this output map.
+      def to_records
+        raise Error, "PSTT_OUT_AMOUNT is required." unless amount
+        raise Error, "PSTT_OUT_SCRIPT is required." unless script_pubkey
+        PSTT.validate_amount!(amount)
+        records = []
+        records << KeyValue.new(OutputTypes::REDEEM_SCRIPT, "".b, redeem_script.to_payload) if redeem_script
+        bip32_derivations.each do |pubkey, info|
+          records << KeyValue.new(OutputTypes::BIP32_DERIVATION, pubkey.htb, info.to_payload)
+        end
+        records << KeyValue.new(OutputTypes::AMOUNT, "".b, [amount].pack("q<"))
+        records << KeyValue.new(OutputTypes::SCRIPT, "".b, script_pubkey.to_payload)
+        proprietaries.each { |p| records << p.to_record(OutputTypes::PROPRIETARY) }
+        unknowns.each do |key, value|
+          buf = StringIO.new(key)
+          type = PSTT.read_compact_size(buf)
+          records << KeyValue.new(type, buf.read || "".b, value)
+        end
+        records
+      end
+
+      def to_payload
+        PSTT.serialize_map(to_records, record_order)
+      end
+
+      # @return [Tapyrus::TxOut] the transaction output this map represents.
+      # @raise [Tapyrus::PSTT::Error] if the amount is out of range.
+      def to_tx_out
+        PSTT.validate_amount!(amount)
+        Tapyrus::TxOut.new(value: amount, script_pubkey: script_pubkey)
+      end
+
+      # @return [Boolean] whether this output holds Colored Coins.
+      def colored?
+        script_pubkey.colored?
+      end
+
+      # @return [Tapyrus::Color::ColorIdentifier] the color of this output, or nil for TPC.
+      def color_id
+        script_pubkey.color_id
+      end
+
+      def ==(other)
+        other.is_a?(Output) && to_payload == other.to_payload
+      end
+    end
+  end
+end

--- a/lib/tapyrus/pstt/proprietary.rb
+++ b/lib/tapyrus/pstt/proprietary.rb
@@ -1,0 +1,54 @@
+module Tapyrus
+  module PSTT
+    # A proprietary record, for applications that need non-standardized fields.
+    class Proprietary
+      # @!attribute [r] identifier
+      #   @return [String] the identifier of the proprietary type user with binary format.
+      attr_reader :identifier
+
+      # @!attribute [r] subtype
+      #   @return [Integer] the subtype defined by the proprietary type user.
+      attr_reader :subtype
+
+      # @!attribute [r] subkeydata
+      #   @return [String] the sub key data with binary format.
+      attr_reader :subkeydata
+
+      # @!attribute [rw] value
+      #   @return [String] the value data with binary format.
+      attr_accessor :value
+
+      def initialize(identifier:, subtype:, subkeydata: "".b, value: "".b)
+        @identifier = identifier
+        @subtype = subtype
+        @subkeydata = subkeydata
+        @value = value
+      end
+
+      # Parse a proprietary record.
+      # @param [Tapyrus::PSTT::KeyValue] record a record whose key type is 0xFC.
+      # @return [Tapyrus::PSTT::Proprietary]
+      def self.parse_from_record(record)
+        buf = StringIO.new(record.keydata)
+        identifier = PSTT.read_bytes(buf, PSTT.read_compact_size(buf))
+        subtype = PSTT.read_compact_size(buf)
+        new(identifier: identifier, subtype: subtype, subkeydata: buf.read || "".b, value: record.value)
+      end
+
+      # @return [String] the key data of this record with binary format.
+      def to_keydata
+        Tapyrus.pack_var_string(identifier) + Tapyrus.pack_var_int(subtype) + subkeydata
+      end
+
+      # @param [Integer] type the key type of the proprietary field in the map this record belongs to.
+      # @return [Tapyrus::PSTT::KeyValue]
+      def to_record(type)
+        KeyValue.new(type, to_keydata, value)
+      end
+
+      def ==(other)
+        other.is_a?(Proprietary) && to_keydata == other.to_keydata && value == other.value
+      end
+    end
+  end
+end

--- a/lib/tapyrus/pstt/tx.rb
+++ b/lib/tapyrus/pstt/tx.rb
@@ -1,0 +1,657 @@
+module Tapyrus
+  module PSTT
+    # A Partially Signed Tapyrus Transaction.
+    #
+    # The methods are grouped by the roles TIP-0174 defines: Creator(::new), Constructor(#add_input,
+    # #add_output, #add_pair, #finish_construction!), Updater(#update_input, #set_sequence),
+    # Signer(#sign), Combiner(#combine), Input Finalizer(#finalize!) and
+    # Transaction Extractor(#extract_tx).
+    class Tx
+      include Tapyrus::HexConverter
+
+      # @!attribute [r] features
+      #   @return [Integer] the features field of the transaction. Tapyrus currently defines only 1.
+      attr_reader :features
+
+      # @!attribute [r] fallback_locktime
+      #   @return [Integer] the locktime to use if no input specifies a required locktime.
+      attr_reader :fallback_locktime
+
+      # @!attribute [r] tx_modifiable
+      #   @return [Integer] the bitfield of PSTT_GLOBAL_TX_MODIFIABLE. nil means not modifiable.
+      attr_reader :tx_modifiable
+
+      # @!attribute [rw] version
+      #   @return [Integer] the version number of this PSTT.
+      attr_accessor :version
+
+      # @!attribute [r] inputs
+      #   @return [Array[Tapyrus::PSTT::Input]] the input maps.
+      attr_reader :inputs
+
+      # @!attribute [r] outputs
+      #   @return [Array[Tapyrus::PSTT::Output]] the output maps.
+      attr_reader :outputs
+
+      # @!attribute [r] xpubs
+      #   @return [Hash] Tapyrus::PSTT::KeyOriginInfo, keyed by the Base58 extended public key.
+      attr_reader :xpubs
+
+      # @!attribute [r] proprietaries
+      #   @return [Array[Tapyrus::PSTT::Proprietary]] the proprietary records.
+      attr_reader :proprietaries
+
+      # @!attribute [r] unknowns
+      #   @return [Hash] the records whose key type this implementation does not know, keyed by complete key.
+      attr_reader :unknowns
+
+      # @!attribute [rw] global_record_order
+      #   @return [Array[String]] the complete keys of the global map this PSTT was parsed from.
+      #     See Tapyrus::PSTT.order_records.
+      attr_accessor :global_record_order
+
+      # Create a new PSTT. This is the Creator role.
+      # @param [Integer] features the features field of the transaction.
+      # @param [Integer] tx_modifiable the initial value of PSTT_GLOBAL_TX_MODIFIABLE.
+      #   Set Tapyrus::PSTT::TxModifiable::INPUTS and/or OUTPUTS if other parties will add
+      #   inputs or outputs. nil fixes the transaction at creation.
+      # @param [Array[Tapyrus::PSTT::Input]] inputs the inputs the Creator creates.
+      # @param [Array[Tapyrus::PSTT::Output]] outputs the outputs the Creator creates.
+      def initialize(features: 1, fallback_locktime: nil, tx_modifiable: nil, version: VERSION, inputs: [], outputs: [])
+        @features = features
+        @fallback_locktime = fallback_locktime
+        @tx_modifiable = tx_modifiable
+        @version = version
+        @inputs = inputs
+        @outputs = outputs
+        @xpubs = {}
+        @proprietaries = []
+        @unknowns = {}
+        @global_record_order = []
+      end
+
+      # Set the features field of the transaction. The signature hash covers it, so it must not
+      # change once the PSTT holds a signature.
+      # @param [Integer] value the features field.
+      # @raise [Tapyrus::PSTT::Error] if the PSTT already contains signatures.
+      def features=(value)
+        if value != @features && signed?
+          raise Error, "The features of a PSTT which already contains signatures must not be changed."
+        end
+        @features = value
+      end
+
+      # Set PSTT_GLOBAL_FALLBACK_LOCKTIME. The signature hash covers the locktime of the
+      # transaction, so a change which alters it is refused once the PSTT holds a signature.
+      # @param [Integer] value the fallback locktime.
+      # @raise [Tapyrus::PSTT::Error] if the change alters the locktime.
+      def fallback_locktime=(value)
+        return @fallback_locktime = value if value == @fallback_locktime
+        previous = @fallback_locktime
+        keeping_locktime("PSTT_GLOBAL_FALLBACK_LOCKTIME") do
+          @fallback_locktime = value
+          -> { @fallback_locktime = previous }
+        end
+      end
+
+      # Set PSTT_GLOBAL_TX_MODIFIABLE. Once the PSTT holds a signature the field records what
+      # those signatures still allow, so it may only be tightened: setting Inputs Modifiable or
+      # Outputs Modifiable again would re-open the very modification a Signer closed by signing,
+      # and clearing Has SIGHASH_SINGLE would drop the pairing rule which keeps a SIGHASH_SINGLE
+      # signature covering its own output.
+      # @param [Integer] value the bitfield, or nil to omit the field.
+      # @raise [Tapyrus::PSTT::Error] if a reserved bit is set, or the value relaxes the field.
+      def tx_modifiable=(value)
+        PSTT.validate_tx_modifiable!(value) if value
+        validate_tx_modifiable_tightens!(value) if signed?
+        @tx_modifiable = value
+      end
+
+      # Parse a PSTT from its raw binary format.
+      # @param [String] payload a PSTT with binary format.
+      # @return [Tapyrus::PSTT::Tx]
+      # @raise [Tapyrus::PSTT::Error] if the payload is not a valid PSTT.
+      def self.parse_from_payload(payload)
+        buf = payload.is_a?(String) ? StringIO.new(payload) : payload
+        unless PSTT.read_bytes(buf, MAGIC.bytesize) == MAGIC
+          raise Error, "Invalid PSTT magic. The payload does not begin with 'pstt' 0xFF."
+        end
+        # Every map is read before any of them is interpreted, so that the declared counts are
+        # compared against the number of maps which is actually there. Assigning maps to inputs
+        # and outputs by the declared counts alone would let a wrong count hand an output map to
+        # the input parser, which reports whichever field of the misread map fails first.
+        maps = []
+        maps << PSTT.parse_map(buf) until buf.eof?
+        raise Error, "The PSTT global map is missing." if maps.empty?
+        pstt, input_count, output_count = parse_global_map(maps.shift)
+        unless maps.size == input_count + output_count
+          raise Error, "The number of maps does not match PSTT_GLOBAL_INPUT_COUNT and PSTT_GLOBAL_OUTPUT_COUNT."
+        end
+        maps.shift(input_count).each { |records| pstt.inputs << Input.parse_from_records(records) }
+        maps.each { |records| pstt.outputs << Output.parse_from_records(records) }
+        pstt
+      end
+
+      # Parse a PSTT from its Base64 format.
+      # @param [String] base64 a PSTT with Base64 format.
+      # @return [Tapyrus::PSTT::Tx]
+      def self.from_base64(base64)
+        payload = base64.unpack1("m0")
+        raise Error, "Invalid Base64 encoding." if payload.nil?
+        parse_from_payload(payload)
+      rescue ArgumentError
+        raise Error, "Invalid Base64 encoding."
+      end
+
+      def to_payload
+        MAGIC + PSTT.serialize_map(global_records, global_record_order) + inputs.map(&:to_payload).join +
+          outputs.map(&:to_payload).join
+      end
+
+      # @return [String] this PSTT with Base64 format, which is used for display and text transport.
+      def to_base64
+        [to_payload].pack("m0")
+      end
+
+      # @return [Array[Tapyrus::PSTT::KeyValue]] the records of the global map.
+      def global_records
+        raise Error, "PSTT_GLOBAL_TX_FEATURES is required." unless features
+        PSTT.validate_tx_modifiable!(tx_modifiable) if tx_modifiable
+        PSTT.validate_version!(version) if version
+        records = []
+        xpubs.each do |xpub, info|
+          keydata = PSTT.parse_field("PSTT_GLOBAL_XPUB") { Tapyrus::ExtPubkey.from_base58(xpub).to_payload }
+          records << KeyValue.new(GlobalTypes::XPUB, keydata, info.to_payload)
+        end
+        records << KeyValue.new(GlobalTypes::TX_FEATURES, "".b, [features].pack("l<"))
+        if fallback_locktime
+          records << KeyValue.new(GlobalTypes::FALLBACK_LOCKTIME, "".b, [fallback_locktime].pack("V"))
+        end
+        records << KeyValue.new(GlobalTypes::INPUT_COUNT, "".b, Tapyrus.pack_var_int(inputs.size))
+        records << KeyValue.new(GlobalTypes::OUTPUT_COUNT, "".b, Tapyrus.pack_var_int(outputs.size))
+        records << KeyValue.new(GlobalTypes::TX_MODIFIABLE, "".b, [tx_modifiable].pack("C")) if tx_modifiable
+        records << KeyValue.new(GlobalTypes::VERSION, "".b, [version].pack("V")) if version && version > 0
+        proprietaries.each { |p| records << p.to_record(GlobalTypes::PROPRIETARY) }
+        unknowns.each do |key, value|
+          buf = StringIO.new(key)
+          type = PSTT.read_compact_size(buf)
+          records << KeyValue.new(type, buf.read || "".b, value)
+        end
+        records
+      end
+
+      # The locktime of the transaction, computed as Determining the Locktime describes.
+      # @return [Integer] the locktime.
+      # @raise [Tapyrus::PSTT::Error] if no locktime kind is acceptable to every input.
+      def locktime
+        time_locktimes = []
+        height_locktimes = []
+        only_time = false
+        only_height = false
+        inputs.each do |input|
+          time = input.required_time_locktime
+          height = input.required_height_locktime
+          next unless time || height
+          time_locktimes << time if time
+          height_locktimes << height if height
+          only_time = true if time && !height
+          only_height = true if height && !time
+        end
+        return fallback_locktime || 0 if time_locktimes.empty? && height_locktimes.empty?
+        if only_time && only_height
+          raise Error, "No locktime kind is acceptable to every input which requires a locktime."
+        end
+        # If both kinds are acceptable, the height-based locktime is chosen.
+        only_time ? time_locktimes.max : height_locktimes.max
+      end
+
+      # Build the transaction determined by the fields of this PSTT.
+      # @param [Integer] sequence override the sequence number of every input.
+      # @param [Boolean] final whether to attach PSTT_IN_FINAL_SCRIPTSIG to each input.
+      # @return [Tapyrus::Tx]
+      def build_tx(sequence: nil, final: false)
+        tx = Tapyrus::Tx.new
+        tx.features = features
+        tx.lock_time = locktime
+        inputs.each do |input|
+          script_sig = final ? input.final_script_sig : Tapyrus::Script.new
+          tx.inputs << Tapyrus::TxIn.new(
+            out_point: input.out_point,
+            script_sig: script_sig,
+            sequence: sequence || input.final_sequence
+          )
+        end
+        outputs.each { |output| tx.outputs << output.to_tx_out }
+        tx
+      end
+
+      # The identifier of this PSTT: the txid of the transaction built from its fields with the
+      # sequence number of every input set to 0.
+      # @return [String] the txid with hex format.
+      def identification_txid
+        build_tx(sequence: 0).txid
+      end
+
+      # @return [Boolean] whether inputs may still be added.
+      def inputs_modifiable?
+        !(tx_modifiable.to_i & TxModifiable::INPUTS).zero?
+      end
+
+      # @return [Boolean] whether outputs may still be added.
+      def outputs_modifiable?
+        !(tx_modifiable.to_i & TxModifiable::OUTPUTS).zero?
+      end
+
+      # @return [Boolean] whether this PSTT contains a signature made with SIGHASH_SINGLE.
+      def has_sighash_single?
+        !(tx_modifiable.to_i & TxModifiable::HAS_SIGHASH_SINGLE).zero?
+      end
+
+      # Whether any input carries a signature. A finalized input counts as signed even though its
+      # PSTT_IN_PARTIAL_SIG records are gone: its signatures moved into PSTT_IN_FINAL_SCRIPTSIG,
+      # where they still commit to everything they committed to before.
+      # @return [Boolean]
+      def signed?
+        inputs.any? { |input| input.signed? || input.finalized? }
+      end
+
+      # Add an input. This is the Constructor role.
+      # @param [Tapyrus::PSTT::Input] input the input to be added.
+      # @return [Tapyrus::PSTT::Tx] self.
+      # @raise [Tapyrus::PSTT::Error] if the input must not be added.
+      def add_input(input)
+        raise Error, "Inputs are not modifiable." unless inputs_modifiable?
+        if has_sighash_single?
+          raise Error, "This PSTT contains a SIGHASH_SINGLE signature. Use #add_pair to keep inputs and outputs paired."
+        end
+        keeping_locktime("The added input") do
+          inputs << input
+          -> { inputs.pop }
+        end
+        self
+      end
+
+      # Add an output. This is the Constructor role.
+      # @param [Tapyrus::PSTT::Output] output the output to be added.
+      # @return [Tapyrus::PSTT::Tx] self.
+      # @raise [Tapyrus::PSTT::Error] if the output must not be added.
+      def add_output(output)
+        raise Error, "Outputs are not modifiable." unless outputs_modifiable?
+        if has_sighash_single?
+          raise Error, "This PSTT contains a SIGHASH_SINGLE signature. Use #add_pair to keep inputs and outputs paired."
+        end
+        outputs << output
+        self
+      end
+
+      # Add an input and an output at matching positions after the existing ones. A PSTT which
+      # contains a SIGHASH_SINGLE signature must preserve that correspondence.
+      # @param [Tapyrus::PSTT::Input] input the input to be added.
+      # @param [Tapyrus::PSTT::Output] output the output to be added.
+      # @return [Tapyrus::PSTT::Tx] self.
+      # @raise [Tapyrus::PSTT::Error] if the pair must not be added.
+      def add_pair(input, output)
+        raise Error, "Inputs are not modifiable." unless inputs_modifiable?
+        raise Error, "Outputs are not modifiable." unless outputs_modifiable?
+        # Appending never moves an existing input or output, so the only thing to enforce is that
+        # the added input has an output at its own position.
+        if inputs.size > outputs.size
+          raise Error, "The added input would have no corresponding output at a matching position."
+        end
+        keeping_locktime("The added input") do
+          inputs << input
+          -> { inputs.pop }
+        end
+        outputs << output
+        self
+      end
+
+      # Declare construction finished by clearing the Inputs Modifiable and Outputs Modifiable flags.
+      # @return [Tapyrus::PSTT::Tx] self.
+      def finish_construction!
+        self.tx_modifiable = tx_modifiable.to_i & ~(TxModifiable::INPUTS | TxModifiable::OUTPUTS)
+        self
+      end
+
+      # Set the sequence number of an input. This is the Updater role.
+      # @param [Integer] index the input index.
+      # @param [Integer] sequence the sequence number.
+      # @return [Tapyrus::PSTT::Tx] self.
+      # @raise [Tapyrus::PSTT::Error] if a collected signature commits to the sequence number.
+      def set_sequence(index, sequence)
+        input = input_at(index)
+        if input.signed? || input.finalized?
+          raise Error, "Input #{index} is already signed. Its sequence number must not be changed."
+        end
+        # A finalized input no longer carries the sighash types of the signatures it was built
+        # from, so which of them commit to which sequence number can no longer be decided. Any
+        # finalized input therefore blocks every sequence change in the PSTT.
+        if inputs.any?(&:finalized?)
+          raise Error, "A finalized input carries signatures which may commit to the sequence number of every input."
+        end
+        if inputs.any? { |i| i.partial_sigs.values.any? { |sig| Input.commits_to_all_sequences?(sig) } }
+          raise Error, "A SIGHASH_ALL signature commits to the sequence number of every input. It must not be changed."
+        end
+        input.sequence = sequence
+        self
+      end
+
+      # The scriptCode used to compute the signature hash of an input.
+      # @param [Integer] index the input index.
+      # @return [Tapyrus::Script]
+      def script_code(index)
+        input_at(index).script_code
+      end
+
+      # Compute the signature hash of an input.
+      # @param [Integer] index the input index.
+      # @param [Integer] sighash_type the sighash type. Defaults to PSTT_IN_SIGHASH_TYPE, or SIGHASH_ALL.
+      # @return [String] the signature hash with binary format.
+      # @raise [Tapyrus::PSTT::Error] if the input must not be signed.
+      def sighash_for_input(index, sighash_type: nil)
+        input = input_at(index)
+        hash_type = resolve_sighash_type(input, sighash_type)
+        if (hash_type & 0x1f) == SIGHASH_TYPE[:single] && index >= outputs.size
+          raise Error, "SIGHASH_SINGLE must not be used for an input which has no corresponding output."
+        end
+        input.validate_for_sign!
+        build_tx.sighash_for_input(index, input.script_code, hash_type: hash_type)
+      end
+
+      # Sign an input. This is the Signer role.
+      # @param [Integer] index the input index.
+      # @param [Tapyrus::Key] key the key to sign with.
+      # @param [Integer] sighash_type the sighash type. Defaults to PSTT_IN_SIGHASH_TYPE, or SIGHASH_ALL.
+      # @param [Symbol] algo the signature scheme. :ecdsa or :schnorr.
+      # @param [Boolean] low_r whether to apply low-R grinding to an ECDSA signature.
+      # @return [String] the signature which was added, with binary format.
+      # @raise [Tapyrus::PSTT::Error] if the input must not be signed.
+      def sign(index, key, sighash_type: nil, algo: :ecdsa, low_r: true)
+        input = input_at(index)
+        # The Input Finalizer removed the PSTT_IN_PARTIAL_SIG records of this input, so a
+        # signature added now would recreate a record the format says is no longer there.
+        raise Error, "Input #{index} is finalized. It takes no further signature." if input.finalized?
+        hash_type = resolve_sighash_type(input, sighash_type)
+        input.validate_signature_algo!(algo)
+        sighash = sighash_for_input(index, sighash_type: hash_type)
+        sig = key.sign(sighash, low_r, nil, algo: algo) + [hash_type].pack("C")
+        input.partial_sigs[key.pubkey] = sig
+        update_tx_modifiable_after_sign(hash_type)
+        sig
+      end
+
+      # Merge another PSTT which has the same identifier into this one. This is the Combiner role.
+      # @param [Tapyrus::PSTT::Tx] other the PSTT to be merged.
+      # @return [Tapyrus::PSTT::Tx] the merged PSTT.
+      # @raise [Tapyrus::PSTT::Error] if the identifiers differ.
+      def combine(other)
+        unless identification_txid == other.identification_txid
+          raise Error, "PSTTs with different identifiers must not be combined."
+        end
+        validate_sequences_agree!(other)
+        modifiable = merge_tx_modifiable(tx_modifiable, other.tx_modifiable)
+        payload =
+          MAGIC + PSTT.serialize_map(merge_records(global_records, other.global_records), global_record_order) +
+            inputs
+              .zip(other.inputs)
+              .map { |a, b| PSTT.serialize_map(merge_records(a.to_records, b.to_records), a.record_order) }
+              .join +
+            outputs
+              .zip(other.outputs)
+              .map { |a, b| PSTT.serialize_map(merge_records(a.to_records, b.to_records), a.record_order) }
+              .join
+        combined = self.class.parse_from_payload(payload)
+        combined.tx_modifiable = modifiable
+        combined
+      end
+
+      # Assemble the complete scriptSig of every input. This is the Input Finalizer role.
+      # @return [Tapyrus::PSTT::Tx] self.
+      # @raise [Tapyrus::PSTT::Error] if the PSTT is still modifiable, or an input cannot be finalized.
+      def finalize!
+        raise Error, "This PSTT has no inputs to finalize." if inputs.empty?
+        if inputs_modifiable? || outputs_modifiable?
+          raise Error, "A PSTT must not be finalized while it is still modifiable."
+        end
+        inputs.each_with_index { |input, index| input.finalize!(verified_partial_sigs(index)) }
+        self
+      end
+
+      # The signatures of an input which verify against the transaction this PSTT describes.
+      #
+      # TIP-0174 has the Input Finalizer check that the collected records are sufficient to
+      # satisfy the script of the output being spent, and a signature which does not verify is
+      # not. It also matters which ones are dropped: the multisig scriptSig takes the first
+      # +threshold+ public keys of the redeem script which carry a signature, so one bad
+      # signature among otherwise good ones would displace a good one and yield a scriptSig
+      # which fails validation, with the signatures needed to spend the output sitting unused in
+      # the same input.
+      # @param [Integer] index the input index.
+      # @return [Hash] the signatures which verify, keyed by public key with hex format.
+      def verified_partial_sigs(index)
+        input = input_at(index)
+        return {} if input.partial_sigs.empty?
+        script_code = input.script_code
+        tx = build_tx
+        input.partial_sigs.select { |pubkey, sig| verified_sig?(tx, index, script_code, pubkey, sig) }
+      end
+
+      # @return [Boolean] whether every input has been finalized.
+      def finalized?
+        !inputs.empty? && inputs.all?(&:finalized?)
+      end
+
+      # Build the final transaction. This is the Transaction Extractor role.
+      # @return [Tapyrus::Tx] the transaction in Tapyrus network serialization.
+      # @raise [Tapyrus::PSTT::Error] if an input has no PSTT_IN_FINAL_SCRIPTSIG.
+      def extract_tx
+        raise Error, "This PSTT has no inputs. A transaction must spend at least one output." if inputs.empty?
+        inputs.each_with_index do |input, index|
+          raise Error, "PSTT_IN_FINAL_SCRIPTSIG for input #{index} is missing." unless input.finalized?
+        end
+        build_tx(final: true)
+      end
+
+      # The amounts being spent, per color. Requires PSTT_IN_UTXO on every input.
+      # @return [Hash] Tapyrus::Color::ColorIdentifier => amount. TPC uses the default color identifier.
+      def input_amounts
+        inputs.each_with_object(Hash.new(0)) do |input, totals|
+          input.validate_utxo!
+          out = input.utxo_output
+          totals[out.color_id || Tapyrus::Color::ColorIdentifier.default] += out.value
+        end
+      end
+
+      # The amounts being created, per color.
+      # @return [Hash] Tapyrus::Color::ColorIdentifier => amount. TPC uses the default color identifier.
+      def output_amounts
+        outputs.each_with_object(Hash.new(0)) do |output, totals|
+          totals[output.color_id || Tapyrus::Color::ColorIdentifier.default] += output.amount
+        end
+      end
+
+      # The TPC fee this transaction pays. Requires PSTT_IN_UTXO on every input.
+      # @return [Integer] the fee in tapy.
+      def fee
+        tpc = Tapyrus::Color::ColorIdentifier.default
+        input_amounts[tpc] - output_amounts[tpc]
+      end
+
+      def ==(other)
+        other.is_a?(Tx) && to_payload == other.to_payload
+      end
+
+      private
+
+      # Build a PSTT from the records of the global map.
+      # @return [Array] the PSTT, the declared input count and the declared output count.
+      def self.parse_global_map(records)
+        pstt = new(features: nil)
+        input_count = nil
+        output_count = nil
+        records.each do |record|
+          case record.type
+          when GlobalTypes::UNSIGNED_TX
+            raise Error, "Global key type 0x00 is reserved."
+          when GlobalTypes::XPUB
+            unless record.keydata.bytesize == 78
+              raise Error, "PSTT_GLOBAL_XPUB keydata must be a 78-byte serialized extended public key."
+            end
+            xpub = PSTT.parse_field("PSTT_GLOBAL_XPUB") { Tapyrus::ExtPubkey.parse_from_payload(record.keydata) }
+            # This PSTT holds the key by its Base58 form, so an extended public key which does not
+            # survive that conversion would be re-serialized as different bytes.
+            unless xpub.to_payload == record.keydata
+              raise Error, "PSTT_GLOBAL_XPUB is not a canonical serialized extended public key."
+            end
+            pstt.xpubs[xpub.to_base58] = KeyOriginInfo.parse_from_payload(record.value)
+          when GlobalTypes::TX_FEATURES
+            PSTT.validate_empty_keydata!(record)
+            pstt.features = PSTT.read_i32(record)
+          when GlobalTypes::FALLBACK_LOCKTIME
+            PSTT.validate_empty_keydata!(record)
+            pstt.fallback_locktime = PSTT.read_u32(record)
+          when GlobalTypes::INPUT_COUNT
+            PSTT.validate_empty_keydata!(record)
+            input_count = PSTT.read_count(record)
+          when GlobalTypes::OUTPUT_COUNT
+            PSTT.validate_empty_keydata!(record)
+            output_count = PSTT.read_count(record)
+          when GlobalTypes::TX_MODIFIABLE
+            PSTT.validate_empty_keydata!(record)
+            pstt.tx_modifiable = PSTT.read_u8(record)
+          when GlobalTypes::VERSION
+            PSTT.validate_empty_keydata!(record)
+            pstt.version = PSTT.read_u32(record)
+            PSTT.validate_version!(pstt.version)
+          when GlobalTypes::PROPRIETARY
+            pstt.proprietaries << Proprietary.parse_from_record(record)
+          else
+            pstt.unknowns[record.key] = record.value
+          end
+        end
+        raise Error, "PSTT_GLOBAL_TX_FEATURES is required." unless pstt.features
+        raise Error, "PSTT_GLOBAL_INPUT_COUNT is required." unless input_count
+        raise Error, "PSTT_GLOBAL_OUTPUT_COUNT is required." unless output_count
+        pstt.global_record_order = records.map(&:key)
+        [pstt, input_count, output_count]
+      end
+      private_class_method :parse_global_map
+
+      def input_at(index)
+        input = inputs[index]
+        raise Error, "Input #{index} does not exist." unless input
+        input
+      end
+
+      def resolve_sighash_type(input, sighash_type)
+        if input.sighash_type && sighash_type && input.sighash_type != sighash_type
+          raise Error, "The sighash type of this input is fixed to #{input.sighash_type} by PSTT_IN_SIGHASH_TYPE."
+        end
+        hash_type = sighash_type || input.sighash_type || SIGHASH_TYPE[:all]
+        # Only the low byte of the sighash type is appended to a signature, while the whole value
+        # is committed to by the signature hash. A value which does not fit in a byte would
+        # therefore produce a signature nobody can verify.
+        PSTT.validate_sighash_type!(hash_type)
+        hash_type
+      end
+
+      # Whether a signature verifies against +tx+ under the scheme its length selects and the
+      # sighash type its last byte names. A record which is not a signature at all, such as
+      # malformed DER or a public key which is not a point, is not valid either, so the decoders
+      # are allowed to fail here rather than to raise.
+      def verified_sig?(tx, index, script_code, pubkey, sig)
+        hash_type = sig[-1].unpack1("C")
+        return false unless SIGHASH_TYPES.include?(hash_type)
+        input = inputs[index]
+        return false if input.sighash_type && input.sighash_type != hash_type
+        return false if (hash_type & 0x1f) == SIGHASH_TYPE[:single] && index >= outputs.size
+        sighash = tx.sighash_for_input(index, script_code, hash_type: hash_type)
+        algo = sig.bytesize == 65 ? :schnorr : :ecdsa
+        Tapyrus::Key.new(pubkey: pubkey).verify(sig[0...-1], sighash, algo: algo)
+      rescue StandardError
+        false
+      end
+
+      # The locktime of the transaction, or nil when the required locktimes of the inputs
+      # contradict each other. Used to compare a hypothetical set of fields against the current
+      # one, where a contradiction counts as a change rather than as an error of its own.
+      def locktime_or_nil
+        locktime
+      rescue Error
+        nil
+      end
+
+      # Apply the change +block+ makes and keep it only if the locktime of the transaction is
+      # unchanged, because every signature commits to the locktime. The block returns a lambda
+      # which undoes its change. A PSTT which holds no signature is changed unconditionally.
+      # @param [String] what the subject of the error message.
+      # @raise [Tapyrus::PSTT::Error] if the change alters the locktime.
+      def keeping_locktime(what)
+        unless signed?
+          yield
+          return
+        end
+        before = locktime_or_nil
+        undo = yield
+        after = locktime_or_nil
+        return if before && after && before == after
+        undo.call
+        raise Error, "#{what} changes the locktime of a PSTT which already contains signatures."
+      end
+
+      # Check that +value+ does not relax PSTT_GLOBAL_TX_MODIFIABLE. See #tx_modifiable=.
+      def validate_tx_modifiable_tightens!(value)
+        before = tx_modifiable.to_i
+        after = value.to_i
+        permissive = TxModifiable::INPUTS | TxModifiable::OUTPUTS
+        loosened = (after & ~before & permissive) | (before & ~after & TxModifiable::HAS_SIGHASH_SINGLE)
+        return if loosened.zero?
+        raise Error, "PSTT_GLOBAL_TX_MODIFIABLE must not be relaxed once the PSTT contains signatures."
+      end
+
+      # Check that the two PSTTs agree on the sequence number of every input.
+      #
+      # The identifier is computed with every sequence number set to 0, so two PSTTs which
+      # disagree about one still identify as the same PSTT. Merging records by their complete key
+      # keeps this PSTT's value and discards the other's, which would invalidate every signature
+      # of the other which commits to the value it carried. This is therefore the conflict a
+      # Combiner refuses rather than resolves.
+      def validate_sequences_agree!(other)
+        inputs.each_with_index do |input, index|
+          next if input.final_sequence == other.inputs[index].final_sequence
+          raise Error, "Input #{index} has a different sequence number in the two PSTTs."
+        end
+      end
+
+      # PSTT_GLOBAL_TX_MODIFIABLE of a combined PSTT.
+      #
+      # Merging records by their complete key keeps one copy's value and discards the other's,
+      # which would resurrect a flag the other copy cleared when it collected a signature and
+      # leave a PSTT which carries a SIGHASH_ALL signature and still claims to accept further
+      # inputs. A flag which permits a modification therefore survives only while both copies
+      # permit it; every other bit, Has SIGHASH_SINGLE included, is the union of the two.
+      def merge_tx_modifiable(mine, theirs)
+        return nil if mine.nil? && theirs.nil?
+        permissive = TxModifiable::INPUTS | TxModifiable::OUTPUTS
+        a = mine.to_i
+        b = theirs.to_i
+        (a & b & permissive) | ((a | b) & ~permissive)
+      end
+
+      def update_tx_modifiable_after_sign(hash_type)
+        base = hash_type & 0x1f
+        flags = tx_modifiable
+        if flags
+          flags &= ~TxModifiable::INPUTS if (hash_type & SIGHASH_TYPE[:anyonecanpay]).zero?
+          flags &= ~TxModifiable::OUTPUTS unless base == SIGHASH_TYPE[:none]
+        end
+        flags = flags.to_i | TxModifiable::HAS_SIGHASH_SINGLE if base == SIGHASH_TYPE[:single]
+        self.tx_modifiable = flags
+      end
+
+      def merge_records(a, b)
+        (a + b).each_with_object({}) { |record, merged| merged[record.key] ||= record }.values
+      end
+    end
+  end
+end

--- a/lib/tapyrus/pstt/tx.rb
+++ b/lib/tapyrus/pstt/tx.rb
@@ -507,6 +507,7 @@ module Tapyrus
           when GlobalTypes::TX_FEATURES
             PSTT.validate_empty_keydata!(record)
             pstt.features = PSTT.read_i32(record)
+            PSTT.validate_features!(pstt.features)
           when GlobalTypes::FALLBACK_LOCKTIME
             PSTT.validate_empty_keydata!(record)
             pstt.fallback_locktime = PSTT.read_u32(record)

--- a/lib/tapyrus/version.rb
+++ b/lib/tapyrus/version.rb
@@ -1,3 +1,3 @@
 module Tapyrus
-  VERSION = "0.3.9"
+  VERSION = "0.4.0"
 end

--- a/spec/fixtures/tip0174/invalid.json
+++ b/spec/fixtures/tip0174/invalid.json
@@ -1,0 +1,242 @@
+[
+  {
+    "id": "wrong-magic",
+    "description": "Magic bytes are the Bitcoin PSBT magic (psbt 0xFF) instead of pstt 0xFF.",
+    "pstt": "cHNidP8BAgQBAAAAAQQBAQEFAQEAAQ4gAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBDwQAAAAAAAEDCECcAAAAAAAAAQQZdqkUAAAAAAAAAAAAAAAAAAAAAAAAAACIrAA=",
+    "expected": {
+      "valid": false,
+      "stage": "parse",
+      "reason": "magic must be 0x70 0x73 0x74 0x74 0xFF"
+    }
+  },
+  {
+    "id": "missing-map-separator",
+    "description": "The final output map is not terminated by a 0x00 separator.",
+    "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEAAQ4gAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBDwQAAAAAAAEDCECcAAAAAAAAAQQZdqkUAAAAAAAAAAAAAAAAAAAAAAAAAACIrA==",
+    "expected": {
+      "valid": false,
+      "stage": "parse",
+      "reason": "every map must be terminated by 0x00"
+    }
+  },
+  {
+    "id": "duplicate-key",
+    "description": "The global map contains two records with the same complete key (PSTT_GLOBAL_TX_FEATURES).",
+    "pstt": "cHN0dP8BAgQBAAAAAQIEAQAAAAEEAQEBBQEBAAEOIAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQ8EAAAAAAABAwhAnAAAAAAAAAEEGXapFAAAAAAAAAAAAAAAAAAAAAAAAAAAiKwA",
+    "expected": {
+      "valid": false,
+      "stage": "parse",
+      "reason": "a map must not contain two records with the same complete key"
+    }
+  },
+  {
+    "id": "missing-global-tx-features",
+    "description": "The global map lacks the required PSTT_GLOBAL_TX_FEATURES record.",
+    "pstt": "cHN0dP8BBAEBAQUBAQABDiABAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEPBAAAAAAAAQMIQJwAAAAAAAABBBl2qRQAAAAAAAAAAAAAAAAAAAAAAAAAAIisAA==",
+    "expected": {
+      "valid": false,
+      "stage": "parse",
+      "reason": "PSTT_GLOBAL_TX_FEATURES is required"
+    }
+  },
+  {
+    "id": "missing-input-previous-txid",
+    "description": "An input map lacks the required PSTT_IN_PREVIOUS_TXID record.",
+    "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEAAQ8EAAAAAAABAwhAnAAAAAAAAAEEGXapFAAAAAAAAAAAAAAAAAAAAAAAAAAAiKwA",
+    "expected": {
+      "valid": false,
+      "stage": "parse",
+      "reason": "PSTT_IN_PREVIOUS_TXID is required in every input map"
+    }
+  },
+  {
+    "id": "missing-output-amount",
+    "description": "An output map lacks the required PSTT_OUT_AMOUNT record.",
+    "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEAAQ4gAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBDwQAAAAAAAEEGXapFAAAAAAAAAAAAAAAAAAAAAAAAAAAiKwA",
+    "expected": {
+      "valid": false,
+      "stage": "parse",
+      "reason": "PSTT_OUT_AMOUNT is required in every output map"
+    }
+  },
+  {
+    "id": "count-mismatch",
+    "description": "PSTT_GLOBAL_INPUT_COUNT declares 2 inputs but only one input map is present.",
+    "pstt": "cHN0dP8BAgQBAAAAAQQBAgEFAQEAAQ4gAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBDwQAAAAAAAEDCECcAAAAAAAAAQQZdqkUAAAAAAAAAAAAAAAAAAAAAAAAAACIrAA=",
+    "expected": {
+      "valid": false,
+      "stage": "parse",
+      "reason": "the numbers of input/output maps must match the declared counts"
+    }
+  },
+  {
+    "id": "utxo-txid-mismatch",
+    "description": "PSTT_IN_UTXO contains a transaction whose hashMalFix does not equal PSTT_IN_PREVIOUS_TXID.",
+    "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEAAQ4gAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIBDwQAAAAAAQBVAQAAAAEREREREREREREREREREREREREREREREREREREREREREQAAAAAA/////wFQwwAAAAAAABl2qRQAAAAAAAAAAAAAAAAAAAAAAAAAAIisAAAAAAABAwhAnAAAAAAAAAEEGXapFAAAAAAAAAAAAAAAAAAAAAAAAAAAiKwA",
+    "expected": {
+      "valid": false,
+      "stage": "rule",
+      "reason": "the Signer must not sign when the UTXO txid does not match PSTT_IN_PREVIOUS_TXID"
+    }
+  },
+  {
+    "id": "global-unsigned-tx-record",
+    "description": "The global map contains a record with the reserved type value 0x00 (the BIP-174 global unsigned transaction).",
+    "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEBAFUBAAAAARERERERERERERERERERERERERERERERERERERERERERAAAAAAD/////AVDDAAAAAAAAGXapFAAAAAAAAAAAAAAAAAAAAAAAAAAAiKwAAAAAAAEOIAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQ8EAAAAAAABAwhAnAAAAAAAAAEEGXapFAAAAAAAAAAAAAAAAAAAAAAAAAAAiKwA",
+    "expected": {
+      "valid": false,
+      "stage": "parse",
+      "reason": "global type value 0x00 is reserved and must not be used"
+    }
+  },
+  {
+    "id": "version-too-high",
+    "description": "PSTT_GLOBAL_VERSION is 1, which is higher than the only defined version (0).",
+    "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEB+wQBAAAAAAEOIAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQ8EAAAAAAABAwhAnAAAAAAAAAEEGXapFAAAAAAAAAAAAAAAAAAAAAAAAAAAiKwA",
+    "expected": {
+      "valid": false,
+      "stage": "parse",
+      "reason": "software must reject a PSTT with a version number higher than 0"
+    }
+  },
+  {
+    "id": "contradictory-locktimes",
+    "description": "One input requires only a time-based locktime and another requires only a height-based locktime; no single locktime kind satisfies both.",
+    "pstt": "cHN0dP8BAgQBAAAAAQQBAgEFAQEAAQ4gAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBDwQAAAAAAREEAPFTZQABDiADAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwEPBAEAAAABEgT0AQAAAAEDCECcAAAAAAAAAQQZdqkUAAAAAAAAAAAAAAAAAAAAAAAAAACIrAA=",
+    "expected": {
+      "valid": false,
+      "stage": "rule",
+      "reason": "no locktime kind is acceptable to all inputs; the PSTT cannot produce a valid transaction"
+    }
+  },
+  {
+    "id": "single-without-corresponding-output",
+    "description": "Input index 1 carries a SIGHASH_SINGLE partial signature but the transaction has only one output.",
+    "pstt": "cHN0dP8BAgQBAAAAAQQBAgEFAQEAAQ4gAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBDwQAAAAAAAEOIAMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAQ8EAQAAACICAxuExVZ7EmRAmV0+1aq6BWXXHhg0YEgZ/5wX9enV3QePRzBEAiAiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIgIgMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMDAAEDCECcAAAAAAAAAQQZdqkUAAAAAAAAAAAAAAAAAAAAAAAAAACIrAA=",
+    "expected": {
+      "valid": false,
+      "stage": "rule",
+      "reason": "an input whose index has no corresponding output must not be signed with SIGHASH_SINGLE"
+    }
+  },
+  {
+    "id": "missing-input-output-index",
+    "description": "An input map has PSTT_IN_PREVIOUS_TXID but lacks the required PSTT_IN_OUTPUT_INDEX record.",
+    "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEAAQ4gAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEAAQMIQJwAAAAAAAABBBl2qRQAAAAAAAAAAAAAAAAAAAAAAAAAAIisAA==",
+    "expected": {
+      "valid": false,
+      "stage": "parse",
+      "reason": "PSTT_IN_OUTPUT_INDEX is required in every input map"
+    }
+  },
+  {
+    "id": "missing-output-script",
+    "description": "An output map has PSTT_OUT_AMOUNT but lacks the required PSTT_OUT_SCRIPT record.",
+    "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEAAQ4gAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBDwQAAAAAAAEDCECcAAAAAAAAAA==",
+    "expected": {
+      "valid": false,
+      "stage": "parse",
+      "reason": "PSTT_OUT_SCRIPT is required in every output map"
+    }
+  },
+  {
+    "id": "time-locktime-too-low",
+    "description": "PSTT_IN_REQUIRED_TIME_LOCKTIME is 499999999, one less than the required minimum of 500000000.",
+    "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEAAQ4gAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBDwQAAAAAAREE/2TNHQABAwhAnAAAAAAAAAEEGXapFAAAAAAAAAAAAAAAAAAAAAAAAAAAiKwA",
+    "expected": {
+      "valid": false,
+      "stage": "parse",
+      "reason": "PSTT_IN_REQUIRED_TIME_LOCKTIME must be greater than or equal to 500000000"
+    }
+  },
+  {
+    "id": "height-locktime-too-high",
+    "description": "PSTT_IN_REQUIRED_HEIGHT_LOCKTIME is 500000000, which is the boundary reserved for time-based locktimes.",
+    "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEAAQ4gAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBDwQAAAAAARIEAGXNHQABAwhAnAAAAAAAAAEEGXapFAAAAAAAAAAAAAAAAAAAAAAAAAAAiKwA",
+    "expected": {
+      "valid": false,
+      "stage": "parse",
+      "reason": "PSTT_IN_REQUIRED_HEIGHT_LOCKTIME must be less than 500000000"
+    }
+  },
+  {
+    "id": "height-locktime-zero",
+    "description": "PSTT_IN_REQUIRED_HEIGHT_LOCKTIME is 0, which is excluded by the \"greater than 0\" requirement.",
+    "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEAAQ4gAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBDwQAAAAAARIEAAAAAAABAwhAnAAAAAAAAAEEGXapFAAAAAAAAAAAAAAAAAAAAAAAAAAAiKwA",
+    "expected": {
+      "valid": false,
+      "stage": "parse",
+      "reason": "PSTT_IN_REQUIRED_HEIGHT_LOCKTIME must be greater than 0"
+    }
+  },
+  {
+    "id": "missing-input-count",
+    "description": "The global map lacks the required PSTT_GLOBAL_INPUT_COUNT record.",
+    "pstt": "cHN0dP8BAgQBAAAAAQUBAQABDiABAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEPBAAAAAAAAQMIQJwAAAAAAAABBBl2qRQAAAAAAAAAAAAAAAAAAAAAAAAAAIisAA==",
+    "expected": {
+      "valid": false,
+      "stage": "parse",
+      "reason": "PSTT_GLOBAL_INPUT_COUNT is required"
+    }
+  },
+  {
+    "id": "missing-output-count",
+    "description": "The global map lacks the required PSTT_GLOBAL_OUTPUT_COUNT record.",
+    "pstt": "cHN0dP8BAgQBAAAAAQQBAQABDiABAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEPBAAAAAAAAQMIQJwAAAAAAAABBBl2qRQAAAAAAAAAAAAAAAAAAAAAAAAAAIisAA==",
+    "expected": {
+      "valid": false,
+      "stage": "parse",
+      "reason": "PSTT_GLOBAL_OUTPUT_COUNT is required"
+    }
+  },
+  {
+    "id": "nonempty-keydata-on-none-field",
+    "description": "PSTT_GLOBAL_TX_FEATURES carries one byte of keydata, but its definition lists no key data.",
+    "pstt": "cHN0dP8CAqoEAQAAAAEEAQEBBQEBAAEOIAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQ8EAAAAAAABAwhAnAAAAAAAAAEEGXapFAAAAAAAAAAAAAAAAAAAAAAAAAAAiKwA",
+    "expected": {
+      "valid": false,
+      "stage": "parse",
+      "reason": "<keydata> must be empty when a field's definition lists no key data"
+    }
+  },
+  {
+    "id": "malformed-pubkey-length",
+    "description": "The keydata of a PSTT_IN_PARTIAL_SIG record is 32 bytes, neither the 33-byte compressed nor the 65-byte uncompressed length a public key must have.",
+    "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEAAQ4gAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBDwQAAAAAIQIDG4TFVnsSZECZXT7VqroFZdceGDRgSBn/nBf16dXdB0cwRAIgIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiICIDMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzAQABAwhAnAAAAAAAAAEEGXapFAAAAAAAAAAAAAAAAAAAAAAAAAAAiKwA",
+    "expected": {
+      "valid": false,
+      "stage": "parse",
+      "reason": "PSTT_IN_PARTIAL_SIG keydata must be a 33- or 65-byte public key"
+    }
+  },
+  {
+    "id": "redeem-script-hash-mismatch",
+    "description": "PSTT_IN_REDEEM_SCRIPT is OP_2, but the P2SH output's scriptPubKey commits to HASH160(OP_1); the redeem script does not hash to the committed value.",
+    "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEAAQ4gc79xovhD/E/ApAVmkfQWytam66jlRLjz4bjJvoNXmR8BDwQAAAAAAQBTAQAAAAFERERERERERERERERERERERERERERERERERERERERERAAAAAAA/////wFQwwAAAAAAABepFNoXRem1Sb0L+hpWmXHHfrowzVpLhwAAAAABBAFSAAEDCECcAAAAAAAAAQQZdqkUAAAAAAAAAAAAAAAAAAAAAAAAAACIrAA=",
+    "expected": {
+      "valid": false,
+      "stage": "rule",
+      "reason": "the Signer must not sign when the redeem script does not hash to the value committed in the output's scriptPubKey"
+    }
+  },
+  {
+    "id": "truncated-value",
+    "description": "The final output map's PSTT_OUT_SCRIPT record declares a valuelen one byte longer than the data actually present in the buffer.",
+    "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEAAQ4gAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBDwQAAAAAAAEDCECcAAAAAAAAAQQadqkUAAAAAAAAAAAAAAAAAAAAAAAAAACIrA==",
+    "expected": {
+      "valid": false,
+      "stage": "parse",
+      "reason": "<valuelen> must not exceed the number of bytes remaining in the map"
+    }
+  },
+  {
+    "id": "non-minimal-keytype",
+    "description": "PSTT_GLOBAL_TX_FEATURES' <keytype> is encoded as 0xfd 0x02 0x00 (3 bytes) instead of the minimal single byte 0x02.",
+    "pstt": "cHN0dP8D/QIABAEAAAABBAEBAQUBAQABDiABAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEPBAAAAAAAAQMIQJwAAAAAAAABBBl2qRQAAAAAAAAAAAAAAAAAAAAAAAAAAIisAA==",
+    "expected": {
+      "valid": false,
+      "stage": "parse",
+      "reason": "<keytype> must be minimally encoded"
+    }
+  }
+]

--- a/spec/fixtures/tip0174/invalid.json
+++ b/spec/fixtures/tip0174/invalid.json
@@ -40,6 +40,26 @@
     }
   },
   {
+    "id": "negative-global-tx-features",
+    "description": "PSTT_GLOBAL_TX_FEATURES is -1, which is not a transaction feature Tapyrus defines.",
+    "pstt": "cHN0dP8BAgT/////AQQBAQEFAQEAAQ4gAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBDwQAAAAAAAEDCECcAAAAAAAAAQQZdqkUAAAAAAAAAAAAAAAAAAAAAAAAAACIrAA=",
+    "expected": {
+      "valid": false,
+      "stage": "parse",
+      "reason": "PSTT_GLOBAL_TX_FEATURES must be greater than 0"
+    }
+  },
+  {
+    "id": "zero-global-tx-features",
+    "description": "PSTT_GLOBAL_TX_FEATURES is 0, which is not a transaction feature Tapyrus defines.",
+    "pstt": "cHN0dP8BAgQAAAAAAQQBAQEFAQEAAQ4gAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBDwQAAAAAAAEDCECcAAAAAAAAAQQZdqkUAAAAAAAAAAAAAAAAAAAAAAAAAACIrAA=",
+    "expected": {
+      "valid": false,
+      "stage": "parse",
+      "reason": "PSTT_GLOBAL_TX_FEATURES must be greater than 0"
+    }
+  },
+  {
     "id": "missing-input-previous-txid",
     "description": "An input map lacks the required PSTT_IN_PREVIOUS_TXID record.",
     "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEAAQ8EAAAAAAABAwhAnAAAAAAAAAEEGXapFAAAAAAAAAAAAAAAAAAAAAAAAAAAiKwA",

--- a/spec/fixtures/tip0174/valid.json
+++ b/spec/fixtures/tip0174/valid.json
@@ -1,0 +1,462 @@
+[
+  {
+    "id": "p2pkh-ecdsa",
+    "description": "Single P2PKH input signed with ECDSA (SIGHASH_ALL). Pays 60000 tapy to key 1, 39000 tapy change to key 2, fee 1000 tapy. Keys derive from SHA256(\"TIP-174 test vectors\") at m/44'/2377'/0'/0/i on the dev network. From the updated stage onward, the global map also carries a PSTT_GLOBAL_XPUB record for the account-level key (m/44'/2377'/0'), matching the derivation paths in the BIP32_DERIVATION records.",
+    "intermediates": [
+      {
+        "input": 0,
+        "pubkey": "02dfe6590eb9dc562d87272fe1248f63e9ed2ce3eb2879fcef30ae3e92720b2cc9",
+        "sighash_type": 1,
+        "script_code": "76a91414c25d2c5eb7248a3841f74d74efe3b4063b383f88ac",
+        "sighash": "59c74c5dd65e2d98d723df091aca2cc253b3c90f8286d83977ce25a457b505a3",
+        "signature": "30450221009c120b0cae2c886085c8b13bcde12137fd799db34a4dfc566389b9a264cd8e4a02201236e69f58915e61b842b665e24215a81743ed1a6530065f03f1ed8c67eb517e01"
+      }
+    ],
+    "stages": [
+      {
+        "name": "created",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQIAAQ4geCTV5dcUOipMfUFAlCGn4hY8MWRwPqiSbffTGnvs0dQBDwQAAAAAAAEDCGDqAAAAAAAAAQQZdqkUVxopLcEbtHFwMPBNVkWsQvKuYN+IrAABAwhYmAAAAAAAAAEEGXapFOVxZknojyIueLwhSn+ibr05gJzRiKwA",
+        "identification_txid": "95a96f3323e3e84152d2c67c2303a6e4fa4f6ad7a8506d118f5ae0cddc12f6d7"
+      },
+      {
+        "name": "updated",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQJPAQQ1h88D30yFpYAAAADhUDs3mDmTEa5u9RuYwYJm2crUdVwT8grGLRVRPUhrIQJm6CZUg1hZuZFr6NZ7yiMNp5XLXUnAPvZC39ghvDurQhDwVlWsLAAAgEkJAIAAAACAAAEOIHgk1eXXFDoqTH1BQJQhp+IWPDFkcD6okm330xp77NHUAQ8EAAAAAAEAVQEAAAABqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqoAAAAAAP////8BoIYBAAAAAAAZdqkUFMJdLF63JIo4QfdNdO/jtAY7OD+IrAAAAAABAwQBAAAAIgYC3+ZZDrncVi2HJy/hJI9j6e0s4+soefzvMK4+knILLMkY8FZVrCwAAIBJCQCAAAAAgAAAAAAAAAAAAAEDCGDqAAAAAAAAAQQZdqkUVxopLcEbtHFwMPBNVkWsQvKuYN+IrAABAwhYmAAAAAAAAAEEGXapFOVxZknojyIueLwhSn+ibr05gJzRiKwiAgNNq7UuzikWjCm6FglCOBMaqDJNLbFsU/0RUJBP8g9i+RjwVlWsLAAAgEkJAIAAAACAAAAAAAIAAAAA",
+        "identification_txid": "95a96f3323e3e84152d2c67c2303a6e4fa4f6ad7a8506d118f5ae0cddc12f6d7"
+      },
+      {
+        "name": "signed",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQJPAQQ1h88D30yFpYAAAADhUDs3mDmTEa5u9RuYwYJm2crUdVwT8grGLRVRPUhrIQJm6CZUg1hZuZFr6NZ7yiMNp5XLXUnAPvZC39ghvDurQhDwVlWsLAAAgEkJAIAAAACAAAEOIHgk1eXXFDoqTH1BQJQhp+IWPDFkcD6okm330xp77NHUAQ8EAAAAAAEAVQEAAAABqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqoAAAAAAP////8BoIYBAAAAAAAZdqkUFMJdLF63JIo4QfdNdO/jtAY7OD+IrAAAAAABAwQBAAAAIgYC3+ZZDrncVi2HJy/hJI9j6e0s4+soefzvMK4+knILLMkY8FZVrCwAAIBJCQCAAAAAgAAAAAAAAAAAIgIC3+ZZDrncVi2HJy/hJI9j6e0s4+soefzvMK4+knILLMlIMEUCIQCcEgsMriyIYIXIsTvN4SE3/Xmds0pN/FZjibmiZM2OSgIgEjbmn1iRXmG4QrZl4kIVqBdD7RplMAZfA/HtjGfrUX4BAAEDCGDqAAAAAAAAAQQZdqkUVxopLcEbtHFwMPBNVkWsQvKuYN+IrAABAwhYmAAAAAAAAAEEGXapFOVxZknojyIueLwhSn+ibr05gJzRiKwiAgNNq7UuzikWjCm6FglCOBMaqDJNLbFsU/0RUJBP8g9i+RjwVlWsLAAAgEkJAIAAAACAAAAAAAIAAAAA",
+        "identification_txid": "95a96f3323e3e84152d2c67c2303a6e4fa4f6ad7a8506d118f5ae0cddc12f6d7"
+      },
+      {
+        "name": "finalized",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQJPAQQ1h88D30yFpYAAAADhUDs3mDmTEa5u9RuYwYJm2crUdVwT8grGLRVRPUhrIQJm6CZUg1hZuZFr6NZ7yiMNp5XLXUnAPvZC39ghvDurQhDwVlWsLAAAgEkJAIAAAACAAAEOIHgk1eXXFDoqTH1BQJQhp+IWPDFkcD6okm330xp77NHUAQ8EAAAAAAEAVQEAAAABqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqoAAAAAAP////8BoIYBAAAAAAAZdqkUFMJdLF63JIo4QfdNdO/jtAY7OD+IrAAAAAABB2tIMEUCIQCcEgsMriyIYIXIsTvN4SE3/Xmds0pN/FZjibmiZM2OSgIgEjbmn1iRXmG4QrZl4kIVqBdD7RplMAZfA/HtjGfrUX4BIQLf5lkOudxWLYcnL+Ekj2Pp7Szj6yh5/O8wrj6ScgssyQABAwhg6gAAAAAAAAEEGXapFFcaKS3BG7RxcDDwTVZFrELyrmDfiKwAAQMIWJgAAAAAAAABBBl2qRTlcWZJ6I8iLni8IUp/om69OYCc0YisIgIDTau1Ls4pFowpuhYJQjgTGqgyTS2xbFP9EVCQT/IPYvkY8FZVrCwAAIBJCQCAAAAAgAAAAAACAAAAAA==",
+        "identification_txid": "95a96f3323e3e84152d2c67c2303a6e4fa4f6ad7a8506d118f5ae0cddc12f6d7"
+      }
+    ],
+    "extracted_tx": "01000000017824d5e5d7143a2a4c7d41409421a7e2163c3164703ea8926df7d31a7becd1d4000000006b4830450221009c120b0cae2c886085c8b13bcde12137fd799db34a4dfc566389b9a264cd8e4a02201236e69f58915e61b842b665e24215a81743ed1a6530065f03f1ed8c67eb517e012102dfe6590eb9dc562d87272fe1248f63e9ed2ce3eb2879fcef30ae3e92720b2cc9ffffffff0260ea0000000000001976a914571a292dc11bb4717030f04d5645ac42f2ae60df88ac58980000000000001976a914e5716649e88f222e78bc214a7fa26ebd39809cd188ac00000000",
+    "final_txid": "6c733ca3e9d0dd72947382cfe78554ae8768963ff71fa78631a8fe65d2085f35"
+  },
+  {
+    "id": "p2pkh-schnorr",
+    "description": "Single P2PKH input signed with the Tapyrus Schnorr scheme (65-byte signature, SIGHASH_ALL). Pays 55000 tapy to key 1, 44500 tapy change to key 2, fee 500 tapy.",
+    "intermediates": [
+      {
+        "input": 0,
+        "pubkey": "02dfe6590eb9dc562d87272fe1248f63e9ed2ce3eb2879fcef30ae3e92720b2cc9",
+        "sighash_type": 1,
+        "script_code": "76a91414c25d2c5eb7248a3841f74d74efe3b4063b383f88ac",
+        "sighash": "b8bd1e97f414f878937e7622635902e018b4d4dd0f14ec12ec13e15d2b1a24af",
+        "signature": "1e481ecbd932e089da0578454834d4b56ae80907e20d3c7a5dc1c246e1fc9821e24f5e3c75e8d2d33cf5d37fcbe4efb48553f224c0a0b06934e3635b82e2c5b301"
+      }
+    ],
+    "stages": [
+      {
+        "name": "created",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQIAAQ4geCTV5dcUOipMfUFAlCGn4hY8MWRwPqiSbffTGnvs0dQBDwQAAAAAAAEDCNjWAAAAAAAAAQQZdqkUVxopLcEbtHFwMPBNVkWsQvKuYN+IrAABAwjUrQAAAAAAAAEEGXapFOVxZknojyIueLwhSn+ibr05gJzRiKwA",
+        "identification_txid": "ec6a5dd1bc7b9257f8cd8af2c2aa66da9e3217b7cda14ab202957a85ecbbcb0f"
+      },
+      {
+        "name": "updated",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQIAAQ4geCTV5dcUOipMfUFAlCGn4hY8MWRwPqiSbffTGnvs0dQBDwQAAAAAAQBVAQAAAAGqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqgAAAAAA/////wGghgEAAAAAABl2qRQUwl0sXrckijhB90107+O0Bjs4P4isAAAAAAEDBAEAAAAiBgLf5lkOudxWLYcnL+Ekj2Pp7Szj6yh5/O8wrj6ScgssyRjwVlWsLAAAgEkJAIAAAACAAAAAAAAAAAAAAQMI2NYAAAAAAAABBBl2qRRXGiktwRu0cXAw8E1WRaxC8q5g34isAAEDCNStAAAAAAAAAQQZdqkU5XFmSeiPIi54vCFKf6JuvTmAnNGIrCICA02rtS7OKRaMKboWCUI4ExqoMk0tsWxT/RFQkE/yD2L5GPBWVawsAACASQkAgAAAAIAAAAAAAgAAAAA=",
+        "identification_txid": "ec6a5dd1bc7b9257f8cd8af2c2aa66da9e3217b7cda14ab202957a85ecbbcb0f"
+      },
+      {
+        "name": "signed",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQIAAQ4geCTV5dcUOipMfUFAlCGn4hY8MWRwPqiSbffTGnvs0dQBDwQAAAAAAQBVAQAAAAGqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqgAAAAAA/////wGghgEAAAAAABl2qRQUwl0sXrckijhB90107+O0Bjs4P4isAAAAAAEDBAEAAAAiBgLf5lkOudxWLYcnL+Ekj2Pp7Szj6yh5/O8wrj6ScgssyRjwVlWsLAAAgEkJAIAAAACAAAAAAAAAAAAiAgLf5lkOudxWLYcnL+Ekj2Pp7Szj6yh5/O8wrj6ScgssyUEeSB7L2TLgidoFeEVINNS1augJB+INPHpdwcJG4fyYIeJPXjx16NLTPPXTf8vk77SFU/IkwKCwaTTjY1uC4sWzAQABAwjY1gAAAAAAAAEEGXapFFcaKS3BG7RxcDDwTVZFrELyrmDfiKwAAQMI1K0AAAAAAAABBBl2qRTlcWZJ6I8iLni8IUp/om69OYCc0YisIgIDTau1Ls4pFowpuhYJQjgTGqgyTS2xbFP9EVCQT/IPYvkY8FZVrCwAAIBJCQCAAAAAgAAAAAACAAAAAA==",
+        "identification_txid": "ec6a5dd1bc7b9257f8cd8af2c2aa66da9e3217b7cda14ab202957a85ecbbcb0f"
+      },
+      {
+        "name": "finalized",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQIAAQ4geCTV5dcUOipMfUFAlCGn4hY8MWRwPqiSbffTGnvs0dQBDwQAAAAAAQBVAQAAAAGqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqgAAAAAA/////wGghgEAAAAAABl2qRQUwl0sXrckijhB90107+O0Bjs4P4isAAAAAAEHZEEeSB7L2TLgidoFeEVINNS1augJB+INPHpdwcJG4fyYIeJPXjx16NLTPPXTf8vk77SFU/IkwKCwaTTjY1uC4sWzASEC3+ZZDrncVi2HJy/hJI9j6e0s4+soefzvMK4+knILLMkAAQMI2NYAAAAAAAABBBl2qRRXGiktwRu0cXAw8E1WRaxC8q5g34isAAEDCNStAAAAAAAAAQQZdqkU5XFmSeiPIi54vCFKf6JuvTmAnNGIrCICA02rtS7OKRaMKboWCUI4ExqoMk0tsWxT/RFQkE/yD2L5GPBWVawsAACASQkAgAAAAIAAAAAAAgAAAAA=",
+        "identification_txid": "ec6a5dd1bc7b9257f8cd8af2c2aa66da9e3217b7cda14ab202957a85ecbbcb0f"
+      }
+    ],
+    "extracted_tx": "01000000017824d5e5d7143a2a4c7d41409421a7e2163c3164703ea8926df7d31a7becd1d40000000064411e481ecbd932e089da0578454834d4b56ae80907e20d3c7a5dc1c246e1fc9821e24f5e3c75e8d2d33cf5d37fcbe4efb48553f224c0a0b06934e3635b82e2c5b3012102dfe6590eb9dc562d87272fe1248f63e9ed2ce3eb2879fcef30ae3e92720b2cc9ffffffff02d8d60000000000001976a914571a292dc11bb4717030f04d5645ac42f2ae60df88acd4ad0000000000001976a914e5716649e88f222e78bc214a7fa26ebd39809cd188ac00000000",
+    "final_txid": "d2f8184595f9ebf5a7b9d0be77dc08e03839fe3d7c8dce98bd40ca4d80be7324"
+  },
+  {
+    "id": "construction-stages",
+    "description": "Cooperative construction walk-through. The Creator starts with an empty PSTT (both modifiable flags set), a Constructor adds one P2PKH input and two outputs, construction is declared finished by clearing the flags, then the input is signed with ECDSA (SIGHASH_ALL), finalized, and extracted. The identification txid changes while inputs/outputs are added and stabilizes once construction is finished.",
+    "intermediates": [
+      {
+        "input": 0,
+        "pubkey": "02dfe6590eb9dc562d87272fe1248f63e9ed2ce3eb2879fcef30ae3e92720b2cc9",
+        "sighash_type": 1,
+        "script_code": "76a91414c25d2c5eb7248a3841f74d74efe3b4063b383f88ac",
+        "sighash": "d2a883e0a6c1beca67c266fde439b65e45a82fe84559ff2660b17914510e6aa9",
+        "signature": "3045022100da0969719206a9b9dd27b112d8dc912ea0f3fbe1b5213ac6b8b1ed9a446eaeae02205bad0ea6d7064c9f2ad5e7249ff5cf4dbf181b87f45122f7d5db2b2c5aa9c25b01"
+      }
+    ],
+    "stages": [
+      {
+        "name": "created-empty",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAAEFAQABBgEDAA==",
+        "identification_txid": "d21633ba23f70118185227be58a63527675641ad37967e2aa461559f577aec43",
+        "tx_modifiable": 3
+      },
+      {
+        "name": "input-added",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQABBgEDAAEOIHgk1eXXFDoqTH1BQJQhp+IWPDFkcD6okm330xp77NHUAQ8EAAAAAAA=",
+        "identification_txid": "3d13ccdef1396ab5c8a7a091e658ad8fd64f406631a338a6bc2733cbd7e715c5",
+        "tx_modifiable": 3
+      },
+      {
+        "name": "outputs-added",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQIBBgEDAAEOIHgk1eXXFDoqTH1BQJQhp+IWPDFkcD6okm330xp77NHUAQ8EAAAAAAABAwhwEQEAAAAAAAEEGXapFFcaKS3BG7RxcDDwTVZFrELyrmDfiKwAAQMISHEAAAAAAAABBBl2qRTlcWZJ6I8iLni8IUp/om69OYCc0YisAA==",
+        "identification_txid": "4b4f954d9c0abbc733c9e16a9d7d28738261053ece236fa0702bfca9ff0b6ef0",
+        "tx_modifiable": 3
+      },
+      {
+        "name": "construction-finished",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQIBBgEAAAEOIHgk1eXXFDoqTH1BQJQhp+IWPDFkcD6okm330xp77NHUAQ8EAAAAAAABAwhwEQEAAAAAAAEEGXapFFcaKS3BG7RxcDDwTVZFrELyrmDfiKwAAQMISHEAAAAAAAABBBl2qRTlcWZJ6I8iLni8IUp/om69OYCc0YisAA==",
+        "identification_txid": "4b4f954d9c0abbc733c9e16a9d7d28738261053ece236fa0702bfca9ff0b6ef0",
+        "tx_modifiable": 0
+      },
+      {
+        "name": "signed",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQIBBgEAAAEOIHgk1eXXFDoqTH1BQJQhp+IWPDFkcD6okm330xp77NHUAQ8EAAAAAAEAVQEAAAABqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqoAAAAAAP////8BoIYBAAAAAAAZdqkUFMJdLF63JIo4QfdNdO/jtAY7OD+IrAAAAAAiBgLf5lkOudxWLYcnL+Ekj2Pp7Szj6yh5/O8wrj6ScgssyRjwVlWsLAAAgEkJAIAAAACAAAAAAAAAAAAiAgLf5lkOudxWLYcnL+Ekj2Pp7Szj6yh5/O8wrj6ScgssyUgwRQIhANoJaXGSBqm53SexEtjckS6g8/vhtSE6xrix7ZpEbq6uAiBbrQ6m1wZMnyrV5ySf9c9Nvxgbh/RRIvfV2yssWqnCWwEAAQMIcBEBAAAAAAABBBl2qRRXGiktwRu0cXAw8E1WRaxC8q5g34isAAEDCEhxAAAAAAAAAQQZdqkU5XFmSeiPIi54vCFKf6JuvTmAnNGIrCICA02rtS7OKRaMKboWCUI4ExqoMk0tsWxT/RFQkE/yD2L5GPBWVawsAACASQkAgAAAAIAAAAAAAgAAAAA=",
+        "identification_txid": "4b4f954d9c0abbc733c9e16a9d7d28738261053ece236fa0702bfca9ff0b6ef0",
+        "tx_modifiable": 0
+      },
+      {
+        "name": "finalized",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQIBBgEAAAEOIHgk1eXXFDoqTH1BQJQhp+IWPDFkcD6okm330xp77NHUAQ8EAAAAAAEAVQEAAAABqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqoAAAAAAP////8BoIYBAAAAAAAZdqkUFMJdLF63JIo4QfdNdO/jtAY7OD+IrAAAAAABB2tIMEUCIQDaCWlxkgapud0nsRLY3JEuoPP74bUhOsa4se2aRG6urgIgW60OptcGTJ8q1eckn/XPTb8YG4f0USL31dsrLFqpwlsBIQLf5lkOudxWLYcnL+Ekj2Pp7Szj6yh5/O8wrj6ScgssyQABAwhwEQEAAAAAAAEEGXapFFcaKS3BG7RxcDDwTVZFrELyrmDfiKwAAQMISHEAAAAAAAABBBl2qRTlcWZJ6I8iLni8IUp/om69OYCc0YisIgIDTau1Ls4pFowpuhYJQjgTGqgyTS2xbFP9EVCQT/IPYvkY8FZVrCwAAIBJCQCAAAAAgAAAAAACAAAAAA==",
+        "identification_txid": "4b4f954d9c0abbc733c9e16a9d7d28738261053ece236fa0702bfca9ff0b6ef0",
+        "tx_modifiable": 0
+      }
+    ],
+    "extracted_tx": "01000000017824d5e5d7143a2a4c7d41409421a7e2163c3164703ea8926df7d31a7becd1d4000000006b483045022100da0969719206a9b9dd27b112d8dc912ea0f3fbe1b5213ac6b8b1ed9a446eaeae02205bad0ea6d7064c9f2ad5e7249ff5cf4dbf181b87f45122f7d5db2b2c5aa9c25b012102dfe6590eb9dc562d87272fe1248f63e9ed2ce3eb2879fcef30ae3e92720b2cc9ffffffff0270110100000000001976a914571a292dc11bb4717030f04d5645ac42f2ae60df88ac48710000000000001976a914e5716649e88f222e78bc214a7fa26ebd39809cd188ac00000000",
+    "final_txid": "001d1ef9c57226b157ff9e979e051e768d80988041df227696f779bc9f2a1666"
+  },
+  {
+    "id": "cp2pkh-transfer",
+    "description": "Colored Coin transfer. Input 0 spends a CP2PKH output holding 100 tokens of color 0xC1||SHA256(P2PKH script of key 0); input 1 spends a 20000 tapy P2PKH output paying the fee. Outputs: 100 tokens to CP2PKH(key 1), 19000 tapy change to P2PKH(key 2); fee 1000 tapy. The scriptCode of the CP2PKH input is the full scriptPubKey including the color identifier prefix; both inputs are signed with ECDSA (SIGHASH_ALL).",
+    "intermediates": [
+      {
+        "input": 0,
+        "pubkey": "02dfe6590eb9dc562d87272fe1248f63e9ed2ce3eb2879fcef30ae3e92720b2cc9",
+        "sighash_type": 1,
+        "script_code": "21c1bdc35ec72390b5128f138301fad91329f17d45ab31d43afa3dea206f2a5a1bc0bc76a91414c25d2c5eb7248a3841f74d74efe3b4063b383f88ac",
+        "sighash": "4b6d98d5f0914c47beb514f259d98bbf3fb6af7a8cedf23bd1a40b1da5ec39af",
+        "signature": "304402201f727d99e45a9c49f124e3775d6fc251f2aeba120fe16b0f3ea1a5f30ce8a36c0220444c093f6012eea4585a957ecf64b262f2933700c01ede76271f6a817e5db92b01"
+      },
+      {
+        "input": 1,
+        "pubkey": "02dfe6590eb9dc562d87272fe1248f63e9ed2ce3eb2879fcef30ae3e92720b2cc9",
+        "sighash_type": 1,
+        "script_code": "76a91414c25d2c5eb7248a3841f74d74efe3b4063b383f88ac",
+        "sighash": "b2c9dff783538fbd85dfe1c99362c482afac59a36fd257d5b8b6112d3c14be84",
+        "signature": "3044022032264842e7998757279863c168cf6ceb27308981d54f5317f40798b6b02f0ec9022046c4165f9fa0fe7965b820ee87576d536702676af8972d43bda62d74f4a8e21901"
+      }
+    ],
+    "stages": [
+      {
+        "name": "created",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAgEFAQIAAQ4g1gO1BZsJ5wGiE7ZKSxAWCqz1Kv/RPC//h/SmibXu/qoBDwQAAAAAAAEOIKqhrhJVXDN94q+sM+xiV/8lleA8pQBF0jekPw7eiYCBAQ8EAAAAAAABAwhkAAAAAAAAAAEEPCHBvcNexyOQtRKPE4MB+tkTKfF9Rasx1Dr6PeogbypaG8C8dqkUVxopLcEbtHFwMPBNVkWsQvKuYN+IrAABAwg4SgAAAAAAAAEEGXapFOVxZknojyIueLwhSn+ibr05gJzRiKwA",
+        "identification_txid": "e34dae9dac1b6f3c998f5091681c43ab30d9d05665722bf7b707b9259bbf72db"
+      },
+      {
+        "name": "updated",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAgEFAQIAAQ4g1gO1BZsJ5wGiE7ZKSxAWCqz1Kv/RPC//h/SmibXu/qoBDwQAAAAAAQB4AQAAAAG7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7uwAAAAAA/////wFkAAAAAAAAADwhwb3DXscjkLUSjxODAfrZEynxfUWrMdQ6+j3qIG8qWhvAvHapFBTCXSxetySKOEH3TXTv47QGOzg/iKwAAAAAAQMEAQAAACIGAt/mWQ653FYthycv4SSPY+ntLOPrKHn87zCuPpJyCyzJGPBWVawsAACASQkAgAAAAIAAAAAAAAAAAAABDiCqoa4SVVwzfeKvrDPsYlf/JZXgPKUARdI3pD8O3omAgQEPBAAAAAABAFUBAAAAAczMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMAAAAAAD/////ASBOAAAAAAAAGXapFBTCXSxetySKOEH3TXTv47QGOzg/iKwAAAAAAQMEAQAAACIGAt/mWQ653FYthycv4SSPY+ntLOPrKHn87zCuPpJyCyzJGPBWVawsAACASQkAgAAAAIAAAAAAAAAAAAABAwhkAAAAAAAAAAEEPCHBvcNexyOQtRKPE4MB+tkTKfF9Rasx1Dr6PeogbypaG8C8dqkUVxopLcEbtHFwMPBNVkWsQvKuYN+IrAABAwg4SgAAAAAAAAEEGXapFOVxZknojyIueLwhSn+ibr05gJzRiKwiAgNNq7UuzikWjCm6FglCOBMaqDJNLbFsU/0RUJBP8g9i+RjwVlWsLAAAgEkJAIAAAACAAAAAAAIAAAAA",
+        "identification_txid": "e34dae9dac1b6f3c998f5091681c43ab30d9d05665722bf7b707b9259bbf72db"
+      },
+      {
+        "name": "signed",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAgEFAQIAAQ4g1gO1BZsJ5wGiE7ZKSxAWCqz1Kv/RPC//h/SmibXu/qoBDwQAAAAAAQB4AQAAAAG7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7uwAAAAAA/////wFkAAAAAAAAADwhwb3DXscjkLUSjxODAfrZEynxfUWrMdQ6+j3qIG8qWhvAvHapFBTCXSxetySKOEH3TXTv47QGOzg/iKwAAAAAAQMEAQAAACIGAt/mWQ653FYthycv4SSPY+ntLOPrKHn87zCuPpJyCyzJGPBWVawsAACASQkAgAAAAIAAAAAAAAAAACICAt/mWQ653FYthycv4SSPY+ntLOPrKHn87zCuPpJyCyzJRzBEAiAfcn2Z5FqcSfEk43ddb8JR8q66Eg/haw8+oaXzDOijbAIgREwJP2AS7qRYWpV+z2SyYvKTNwDAHt52Jx9qgX5duSsBAAEOIKqhrhJVXDN94q+sM+xiV/8lleA8pQBF0jekPw7eiYCBAQ8EAAAAAAEAVQEAAAABzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMwAAAAAAP////8BIE4AAAAAAAAZdqkUFMJdLF63JIo4QfdNdO/jtAY7OD+IrAAAAAABAwQBAAAAIgYC3+ZZDrncVi2HJy/hJI9j6e0s4+soefzvMK4+knILLMkY8FZVrCwAAIBJCQCAAAAAgAAAAAAAAAAAIgIC3+ZZDrncVi2HJy/hJI9j6e0s4+soefzvMK4+knILLMlHMEQCIDImSELnmYdXJ5hjwWjPbOsnMImB1U9TF/QHmLawLw7JAiBGxBZfn6D+eWW4IO6HV21TZwJnaviXLUO9pi109KjiGQEAAQMIZAAAAAAAAAABBDwhwb3DXscjkLUSjxODAfrZEynxfUWrMdQ6+j3qIG8qWhvAvHapFFcaKS3BG7RxcDDwTVZFrELyrmDfiKwAAQMIOEoAAAAAAAABBBl2qRTlcWZJ6I8iLni8IUp/om69OYCc0YisIgIDTau1Ls4pFowpuhYJQjgTGqgyTS2xbFP9EVCQT/IPYvkY8FZVrCwAAIBJCQCAAAAAgAAAAAACAAAAAA==",
+        "identification_txid": "e34dae9dac1b6f3c998f5091681c43ab30d9d05665722bf7b707b9259bbf72db"
+      },
+      {
+        "name": "finalized",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAgEFAQIAAQ4g1gO1BZsJ5wGiE7ZKSxAWCqz1Kv/RPC//h/SmibXu/qoBDwQAAAAAAQB4AQAAAAG7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7uwAAAAAA/////wFkAAAAAAAAADwhwb3DXscjkLUSjxODAfrZEynxfUWrMdQ6+j3qIG8qWhvAvHapFBTCXSxetySKOEH3TXTv47QGOzg/iKwAAAAAAQdqRzBEAiAfcn2Z5FqcSfEk43ddb8JR8q66Eg/haw8+oaXzDOijbAIgREwJP2AS7qRYWpV+z2SyYvKTNwDAHt52Jx9qgX5duSsBIQLf5lkOudxWLYcnL+Ekj2Pp7Szj6yh5/O8wrj6ScgssyQABDiCqoa4SVVwzfeKvrDPsYlf/JZXgPKUARdI3pD8O3omAgQEPBAAAAAABAFUBAAAAAczMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMAAAAAAD/////ASBOAAAAAAAAGXapFBTCXSxetySKOEH3TXTv47QGOzg/iKwAAAAAAQdqRzBEAiAyJkhC55mHVyeYY8Foz2zrJzCJgdVPUxf0B5i2sC8OyQIgRsQWX5+g/nlluCDuh1dtU2cCZ2r4ly1DvaYtdPSo4hkBIQLf5lkOudxWLYcnL+Ekj2Pp7Szj6yh5/O8wrj6ScgssyQABAwhkAAAAAAAAAAEEPCHBvcNexyOQtRKPE4MB+tkTKfF9Rasx1Dr6PeogbypaG8C8dqkUVxopLcEbtHFwMPBNVkWsQvKuYN+IrAABAwg4SgAAAAAAAAEEGXapFOVxZknojyIueLwhSn+ibr05gJzRiKwiAgNNq7UuzikWjCm6FglCOBMaqDJNLbFsU/0RUJBP8g9i+RjwVlWsLAAAgEkJAIAAAACAAAAAAAIAAAAA",
+        "identification_txid": "e34dae9dac1b6f3c998f5091681c43ab30d9d05665722bf7b707b9259bbf72db"
+      }
+    ],
+    "extracted_tx": "0100000002d603b5059b09e701a213b64a4b10160aacf52affd13c2fff87f4a689b5eefeaa000000006a47304402201f727d99e45a9c49f124e3775d6fc251f2aeba120fe16b0f3ea1a5f30ce8a36c0220444c093f6012eea4585a957ecf64b262f2933700c01ede76271f6a817e5db92b012102dfe6590eb9dc562d87272fe1248f63e9ed2ce3eb2879fcef30ae3e92720b2cc9ffffffffaaa1ae12555c337de2afac33ec6257ff2595e03ca50045d237a43f0ede898081000000006a473044022032264842e7998757279863c168cf6ceb27308981d54f5317f40798b6b02f0ec9022046c4165f9fa0fe7965b820ee87576d536702676af8972d43bda62d74f4a8e219012102dfe6590eb9dc562d87272fe1248f63e9ed2ce3eb2879fcef30ae3e92720b2cc9ffffffff0264000000000000003c21c1bdc35ec72390b5128f138301fad91329f17d45ab31d43afa3dea206f2a5a1bc0bc76a914571a292dc11bb4717030f04d5645ac42f2ae60df88ac384a0000000000001976a914e5716649e88f222e78bc214a7fa26ebd39809cd188ac00000000",
+    "final_txid": "70b38e6892f519e4bb477f0f6d918c3e6bdf60f5852a292b549b0eb762e5239d"
+  },
+  {
+    "id": "cp2sh-multisig-combine",
+    "description": "A 2-of-2 CP2SH multisig token input (200 tokens, redeem script OP_2 <key3> <key4> OP_2 OP_CHECKMULTISIG) plus a P2PKH fee input. Signer A (holding key 3 and the fee key 0) and signer B (holding key 4) sign independently from the updated stage; a Combiner merges the two PSTTs into one. The scriptCode of the CP2SH input is the redeem script without the color identifier prefix. Signer B also attaches a record of type 0x20, which this TIP does not define; it must be preserved unchanged through the combined and finalized stages.",
+    "intermediates": [
+      {
+        "input": 0,
+        "pubkey": "028b6d5d2e8a851bad35065f2eef00a50393cf61c3c2379fbd33b6064a863884aa",
+        "sighash_type": 1,
+        "script_code": "5221028b6d5d2e8a851bad35065f2eef00a50393cf61c3c2379fbd33b6064a863884aa21033c95e0675ee2fea306efeaa468523d3e0c053c25de4be1ff4b4f181675d0413552ae",
+        "sighash": "f19966624894c461c87c03d5bbf25ca73708fa15e90e36cd1f2a5f9b044e1030",
+        "signature": "304402205155c9fa07256ff832badaf0d2c0771f24557ae3eba587ec4b71673006710511022075b9f8b03ba332f98d8ae1e96211f5a75b6afc7920f439444067d88c0d6b2faa01"
+      },
+      {
+        "input": 0,
+        "pubkey": "033c95e0675ee2fea306efeaa468523d3e0c053c25de4be1ff4b4f181675d04135",
+        "sighash_type": 1,
+        "script_code": "5221028b6d5d2e8a851bad35065f2eef00a50393cf61c3c2379fbd33b6064a863884aa21033c95e0675ee2fea306efeaa468523d3e0c053c25de4be1ff4b4f181675d0413552ae",
+        "sighash": "f19966624894c461c87c03d5bbf25ca73708fa15e90e36cd1f2a5f9b044e1030",
+        "signature": "304402201e2bd73a2ded4a555dc5523a11ac0e4d781b44fcaf371054f291a6eb41d6673a02200d30cdf2d489d81ba0d147f4c200badbaa72875ef2a9c5fe79334a7b082f220101"
+      },
+      {
+        "input": 1,
+        "pubkey": "02dfe6590eb9dc562d87272fe1248f63e9ed2ce3eb2879fcef30ae3e92720b2cc9",
+        "sighash_type": 1,
+        "script_code": "76a91414c25d2c5eb7248a3841f74d74efe3b4063b383f88ac",
+        "sighash": "704aa3e208c25ef20badabeb4b9fc1805fc7ee1acd6a66e148172ed3e165a095",
+        "signature": "3045022100db867890a117c14dc844c8e753649f1559a08b498dc9c877aea869d662afe9bb02203a772978689fb369ac2af2a8bce661dd6c9ecbee61ff98cfbfd674dd631f40a501"
+      }
+    ],
+    "stages": [
+      {
+        "name": "created",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAgEFAQIAAQ4ghVmpNP0WCaO7xZHDc4zKbUMtqP24VWM7448W1/lZHQsBDwQAAAAAAAEOIBCmne4Q2FyRPio2x3b8dDpTlWGtb2AaupYqStN5GHCsAQ8EAAAAAAABAwjIAAAAAAAAAAEEPCHBvcNexyOQtRKPE4MB+tkTKfF9Rasx1Dr6PeogbypaG8C8dqkUVxopLcEbtHFwMPBNVkWsQvKuYN+IrAABAwg4SgAAAAAAAAEEGXapFOVxZknojyIueLwhSn+ibr05gJzRiKwA",
+        "identification_txid": "936875f1e861669edecd2a9d0e017781f812b26eb5107129e639cb7d3f46a34f"
+      },
+      {
+        "name": "updated",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAgEFAQIAAQ4ghVmpNP0WCaO7xZHDc4zKbUMtqP24VWM7448W1/lZHQsBDwQAAAAAAQB2AQAAAAHd3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3QAAAAAA/////wHIAAAAAAAAADohwb3DXscjkLUSjxODAfrZEynxfUWrMdQ6+j3qIG8qWhvAvKkUOyFDvSW5YUzkG8OGCXCJq4EGl8SHAAAAAAEDBAEAAAABBEdSIQKLbV0uioUbrTUGXy7vAKUDk89hw8I3n70ztgZKhjiEqiEDPJXgZ17i/qMG7+qkaFI9PgwFPCXeS+H/S08YFnXQQTVSriIGAottXS6KhRutNQZfLu8ApQOTz2HDwjefvTO2BkqGOISqGPBWVawsAACASQkAgAAAAIAAAAAAAwAAACIGAzyV4Gde4v6jBu/qpGhSPT4MBTwl3kvh/0tPGBZ10EE1GPBWVawsAACASQkAgAAAAIAAAAAABAAAAAABDiAQpp3uENhckT4qNsd2/HQ6U5VhrW9gGrqWKkrTeRhwrAEPBAAAAAABAFUBAAAAAe7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7uAAAAAAD/////ASBOAAAAAAAAGXapFBTCXSxetySKOEH3TXTv47QGOzg/iKwAAAAAAQMEAQAAACIGAt/mWQ653FYthycv4SSPY+ntLOPrKHn87zCuPpJyCyzJGPBWVawsAACASQkAgAAAAIAAAAAAAAAAAAABAwjIAAAAAAAAAAEEPCHBvcNexyOQtRKPE4MB+tkTKfF9Rasx1Dr6PeogbypaG8C8dqkUVxopLcEbtHFwMPBNVkWsQvKuYN+IrAABAwg4SgAAAAAAAAEEGXapFOVxZknojyIueLwhSn+ibr05gJzRiKwiAgNNq7UuzikWjCm6FglCOBMaqDJNLbFsU/0RUJBP8g9i+RjwVlWsLAAAgEkJAIAAAACAAAAAAAIAAAAA",
+        "identification_txid": "936875f1e861669edecd2a9d0e017781f812b26eb5107129e639cb7d3f46a34f"
+      },
+      {
+        "name": "signed-a",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAgEFAQIAAQ4ghVmpNP0WCaO7xZHDc4zKbUMtqP24VWM7448W1/lZHQsBDwQAAAAAAQB2AQAAAAHd3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3QAAAAAA/////wHIAAAAAAAAADohwb3DXscjkLUSjxODAfrZEynxfUWrMdQ6+j3qIG8qWhvAvKkUOyFDvSW5YUzkG8OGCXCJq4EGl8SHAAAAAAEDBAEAAAABBEdSIQKLbV0uioUbrTUGXy7vAKUDk89hw8I3n70ztgZKhjiEqiEDPJXgZ17i/qMG7+qkaFI9PgwFPCXeS+H/S08YFnXQQTVSriIGAottXS6KhRutNQZfLu8ApQOTz2HDwjefvTO2BkqGOISqGPBWVawsAACASQkAgAAAAIAAAAAAAwAAACIGAzyV4Gde4v6jBu/qpGhSPT4MBTwl3kvh/0tPGBZ10EE1GPBWVawsAACASQkAgAAAAIAAAAAABAAAACICAottXS6KhRutNQZfLu8ApQOTz2HDwjefvTO2BkqGOISqRzBEAiBRVcn6ByVv+DK62vDSwHcfJFV64+ulh+xLcWcwBnEFEQIgdbn4sDujMvmNiuHpYhH1p1tq/Hkg9DlEQGfYjA1rL6oBAAEOIBCmne4Q2FyRPio2x3b8dDpTlWGtb2AaupYqStN5GHCsAQ8EAAAAAAEAVQEAAAAB7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u4AAAAAAP////8BIE4AAAAAAAAZdqkUFMJdLF63JIo4QfdNdO/jtAY7OD+IrAAAAAABAwQBAAAAIgYC3+ZZDrncVi2HJy/hJI9j6e0s4+soefzvMK4+knILLMkY8FZVrCwAAIBJCQCAAAAAgAAAAAAAAAAAIgIC3+ZZDrncVi2HJy/hJI9j6e0s4+soefzvMK4+knILLMlIMEUCIQDbhniQoRfBTchEyOdTZJ8VWaCLSY3JyHeuqGnWYq/puwIgOncpeGifs2msKvKovOZh3Wyey+5h/5jPv9Z03WMfQKUBAAEDCMgAAAAAAAAAAQQ8IcG9w17HI5C1Eo8TgwH62RMp8X1FqzHUOvo96iBvKlobwLx2qRRXGiktwRu0cXAw8E1WRaxC8q5g34isAAEDCDhKAAAAAAAAAQQZdqkU5XFmSeiPIi54vCFKf6JuvTmAnNGIrCICA02rtS7OKRaMKboWCUI4ExqoMk0tsWxT/RFQkE/yD2L5GPBWVawsAACASQkAgAAAAIAAAAAAAgAAAAA=",
+        "identification_txid": "936875f1e861669edecd2a9d0e017781f812b26eb5107129e639cb7d3f46a34f"
+      },
+      {
+        "name": "signed-b",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAgEFAQIAAQ4ghVmpNP0WCaO7xZHDc4zKbUMtqP24VWM7448W1/lZHQsBDwQAAAAAAQB2AQAAAAHd3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3QAAAAAA/////wHIAAAAAAAAADohwb3DXscjkLUSjxODAfrZEynxfUWrMdQ6+j3qIG8qWhvAvKkUOyFDvSW5YUzkG8OGCXCJq4EGl8SHAAAAAAEDBAEAAAABBEdSIQKLbV0uioUbrTUGXy7vAKUDk89hw8I3n70ztgZKhjiEqiEDPJXgZ17i/qMG7+qkaFI9PgwFPCXeS+H/S08YFnXQQTVSriIGAottXS6KhRutNQZfLu8ApQOTz2HDwjefvTO2BkqGOISqGPBWVawsAACASQkAgAAAAIAAAAAAAwAAACIGAzyV4Gde4v6jBu/qpGhSPT4MBTwl3kvh/0tPGBZ10EE1GPBWVawsAACASQkAgAAAAIAAAAAABAAAACICAzyV4Gde4v6jBu/qpGhSPT4MBTwl3kvh/0tPGBZ10EE1RzBEAiAeK9c6Le1KVV3FUjoRrA5NeBtE/K83EFTykabrQdZnOgIgDTDN8tSJ2Bug0Uf0wgC626pyh17yqcX+eTNKewgvIgEBASAMZnV0dXJlLWZpZWxkAAEOIBCmne4Q2FyRPio2x3b8dDpTlWGtb2AaupYqStN5GHCsAQ8EAAAAAAEAVQEAAAAB7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u4AAAAAAP////8BIE4AAAAAAAAZdqkUFMJdLF63JIo4QfdNdO/jtAY7OD+IrAAAAAABAwQBAAAAIgYC3+ZZDrncVi2HJy/hJI9j6e0s4+soefzvMK4+knILLMkY8FZVrCwAAIBJCQCAAAAAgAAAAAAAAAAAAAEDCMgAAAAAAAAAAQQ8IcG9w17HI5C1Eo8TgwH62RMp8X1FqzHUOvo96iBvKlobwLx2qRRXGiktwRu0cXAw8E1WRaxC8q5g34isAAEDCDhKAAAAAAAAAQQZdqkU5XFmSeiPIi54vCFKf6JuvTmAnNGIrCICA02rtS7OKRaMKboWCUI4ExqoMk0tsWxT/RFQkE/yD2L5GPBWVawsAACASQkAgAAAAIAAAAAAAgAAAAA=",
+        "identification_txid": "936875f1e861669edecd2a9d0e017781f812b26eb5107129e639cb7d3f46a34f"
+      },
+      {
+        "name": "combined",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAgEFAQIAAQ4ghVmpNP0WCaO7xZHDc4zKbUMtqP24VWM7448W1/lZHQsBDwQAAAAAAQB2AQAAAAHd3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3QAAAAAA/////wHIAAAAAAAAADohwb3DXscjkLUSjxODAfrZEynxfUWrMdQ6+j3qIG8qWhvAvKkUOyFDvSW5YUzkG8OGCXCJq4EGl8SHAAAAAAEDBAEAAAABBEdSIQKLbV0uioUbrTUGXy7vAKUDk89hw8I3n70ztgZKhjiEqiEDPJXgZ17i/qMG7+qkaFI9PgwFPCXeS+H/S08YFnXQQTVSriIGAottXS6KhRutNQZfLu8ApQOTz2HDwjefvTO2BkqGOISqGPBWVawsAACASQkAgAAAAIAAAAAAAwAAACIGAzyV4Gde4v6jBu/qpGhSPT4MBTwl3kvh/0tPGBZ10EE1GPBWVawsAACASQkAgAAAAIAAAAAABAAAACICAottXS6KhRutNQZfLu8ApQOTz2HDwjefvTO2BkqGOISqRzBEAiBRVcn6ByVv+DK62vDSwHcfJFV64+ulh+xLcWcwBnEFEQIgdbn4sDujMvmNiuHpYhH1p1tq/Hkg9DlEQGfYjA1rL6oBIgIDPJXgZ17i/qMG7+qkaFI9PgwFPCXeS+H/S08YFnXQQTVHMEQCIB4r1zot7UpVXcVSOhGsDk14G0T8rzcQVPKRputB1mc6AiANMM3y1InYG6DRR/TCALrbqnKHXvKpxf55M0p7CC8iAQEBIAxmdXR1cmUtZmllbGQAAQ4gEKad7hDYXJE+KjbHdvx0OlOVYa1vYBq6lipK03kYcKwBDwQAAAAAAQBVAQAAAAHu7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7gAAAAAA/////wEgTgAAAAAAABl2qRQUwl0sXrckijhB90107+O0Bjs4P4isAAAAAAEDBAEAAAAiBgLf5lkOudxWLYcnL+Ekj2Pp7Szj6yh5/O8wrj6ScgssyRjwVlWsLAAAgEkJAIAAAACAAAAAAAAAAAAiAgLf5lkOudxWLYcnL+Ekj2Pp7Szj6yh5/O8wrj6ScgssyUgwRQIhANuGeJChF8FNyETI51NknxVZoItJjcnId66oadZir+m7AiA6dyl4aJ+zaawq8qi85mHdbJ7L7mH/mM+/1nTdYx9ApQEAAQMIyAAAAAAAAAABBDwhwb3DXscjkLUSjxODAfrZEynxfUWrMdQ6+j3qIG8qWhvAvHapFFcaKS3BG7RxcDDwTVZFrELyrmDfiKwAAQMIOEoAAAAAAAABBBl2qRTlcWZJ6I8iLni8IUp/om69OYCc0YisIgIDTau1Ls4pFowpuhYJQjgTGqgyTS2xbFP9EVCQT/IPYvkY8FZVrCwAAIBJCQCAAAAAgAAAAAACAAAAAA==",
+        "identification_txid": "936875f1e861669edecd2a9d0e017781f812b26eb5107129e639cb7d3f46a34f"
+      },
+      {
+        "name": "finalized",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAgEFAQIAAQ4ghVmpNP0WCaO7xZHDc4zKbUMtqP24VWM7448W1/lZHQsBDwQAAAAAAQB2AQAAAAHd3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3QAAAAAA/////wHIAAAAAAAAADohwb3DXscjkLUSjxODAfrZEynxfUWrMdQ6+j3qIG8qWhvAvKkUOyFDvSW5YUzkG8OGCXCJq4EGl8SHAAAAAAEH2QBHMEQCIFFVyfoHJW/4Mrra8NLAdx8kVXrj66WH7EtxZzAGcQURAiB1ufiwO6My+Y2K4eliEfWnW2r8eSD0OURAZ9iMDWsvqgFHMEQCIB4r1zot7UpVXcVSOhGsDk14G0T8rzcQVPKRputB1mc6AiANMM3y1InYG6DRR/TCALrbqnKHXvKpxf55M0p7CC8iAQFHUiECi21dLoqFG601Bl8u7wClA5PPYcPCN5+9M7YGSoY4hKohAzyV4Gde4v6jBu/qpGhSPT4MBTwl3kvh/0tPGBZ10EE1Uq4BIAxmdXR1cmUtZmllbGQAAQ4gEKad7hDYXJE+KjbHdvx0OlOVYa1vYBq6lipK03kYcKwBDwQAAAAAAQBVAQAAAAHu7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7gAAAAAA/////wEgTgAAAAAAABl2qRQUwl0sXrckijhB90107+O0Bjs4P4isAAAAAAEHa0gwRQIhANuGeJChF8FNyETI51NknxVZoItJjcnId66oadZir+m7AiA6dyl4aJ+zaawq8qi85mHdbJ7L7mH/mM+/1nTdYx9ApQEhAt/mWQ653FYthycv4SSPY+ntLOPrKHn87zCuPpJyCyzJAAEDCMgAAAAAAAAAAQQ8IcG9w17HI5C1Eo8TgwH62RMp8X1FqzHUOvo96iBvKlobwLx2qRRXGiktwRu0cXAw8E1WRaxC8q5g34isAAEDCDhKAAAAAAAAAQQZdqkU5XFmSeiPIi54vCFKf6JuvTmAnNGIrCICA02rtS7OKRaMKboWCUI4ExqoMk0tsWxT/RFQkE/yD2L5GPBWVawsAACASQkAgAAAAIAAAAAAAgAAAAA=",
+        "identification_txid": "936875f1e861669edecd2a9d0e017781f812b26eb5107129e639cb7d3f46a34f"
+      }
+    ],
+    "extracted_tx": "01000000028559a934fd1609a3bbc591c3738cca6d432da8fdb855633be38f16d7f9591d0b00000000d90047304402205155c9fa07256ff832badaf0d2c0771f24557ae3eba587ec4b71673006710511022075b9f8b03ba332f98d8ae1e96211f5a75b6afc7920f439444067d88c0d6b2faa0147304402201e2bd73a2ded4a555dc5523a11ac0e4d781b44fcaf371054f291a6eb41d6673a02200d30cdf2d489d81ba0d147f4c200badbaa72875ef2a9c5fe79334a7b082f220101475221028b6d5d2e8a851bad35065f2eef00a50393cf61c3c2379fbd33b6064a863884aa21033c95e0675ee2fea306efeaa468523d3e0c053c25de4be1ff4b4f181675d0413552aeffffffff10a69dee10d85c913e2a36c776fc743a539561ad6f601aba962a4ad3791870ac000000006b483045022100db867890a117c14dc844c8e753649f1559a08b498dc9c877aea869d662afe9bb02203a772978689fb369ac2af2a8bce661dd6c9ecbee61ff98cfbfd674dd631f40a5012102dfe6590eb9dc562d87272fe1248f63e9ed2ce3eb2879fcef30ae3e92720b2cc9ffffffff02c8000000000000003c21c1bdc35ec72390b5128f138301fad91329f17d45ab31d43afa3dea206f2a5a1bc0bc76a914571a292dc11bb4717030f04d5645ac42f2ae60df88ac384a0000000000001976a914e5716649e88f222e78bc214a7fa26ebd39809cd188ac00000000",
+    "final_txid": "da211c6cdba004ac37152f2a7013586db2944cca8ac1fcc6631f5baf42a21768"
+  },
+  {
+    "id": "fee-provider-noninteractive",
+    "description": "Fee provider workflow, non-interactive variant (exact-fee UTXO). The user constructs a 100-token CP2PKH transfer with no TPC and signs with SIGHASH_ALL|SIGHASH_ANYONECANPAY, leaving the Inputs Modifiable flag set. The fee provider adds one 1000-tapy P2PKH input whose value is exactly the fee, signs it with SIGHASH_ALL (clearing Inputs Modifiable), finalizes, and extracts. The user's sighash is computed over the single-input transaction and stays valid after the fee input is added, which the verifier confirms by recomputing it from the final two-input transaction.",
+    "intermediates": [
+      {
+        "input": 0,
+        "pubkey": "02dfe6590eb9dc562d87272fe1248f63e9ed2ce3eb2879fcef30ae3e92720b2cc9",
+        "sighash_type": 129,
+        "script_code": "21c1bdc35ec72390b5128f138301fad91329f17d45ab31d43afa3dea206f2a5a1bc0bc76a91414c25d2c5eb7248a3841f74d74efe3b4063b383f88ac",
+        "sighash": "35b3893b789210b9f1df1efe10a42937d358dc926d0f8d3315e9cf124c8a4906",
+        "signature": "3045022100ab18c9918bda646dc7817540ddf9a26d060bc276d307e86a5ef0e601eab36ad40220242b87c4ba7c8de3adcdfd688527d46a5529f365a15f570b6eca9c78990e7e1b81"
+      },
+      {
+        "input": 1,
+        "pubkey": "03030c9adf9daaa50d179c04fc16a3fbf7985e32021343680300a2a511f42c0341",
+        "sighash_type": 1,
+        "script_code": "76a914dcac7d84c6844c82f715802a834c5671bdc5821288ac",
+        "sighash": "1a6c6e2a5a94b28a066dcd64a88f43d987944b635a1790576feb0085872ed564",
+        "signature": "3045022100b8cc4f119e0d783b095d6687745011f16b369a667d94d9d41a472f91a8d15eea0220653574b5b025439f0c937c605ebd6541076859ab6ca7141ac592b9dcab63dad901"
+      }
+    ],
+    "stages": [
+      {
+        "name": "user-constructed",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEBBgEBAAEOIAOemco6/ra8aNcan5VF7DZxq2F983TeOQdh7zLLh/AhAQ8EAAAAAAABAwhkAAAAAAAAAAEEPCHBvcNexyOQtRKPE4MB+tkTKfF9Rasx1Dr6PeogbypaG8C8dqkUVxopLcEbtHFwMPBNVkWsQvKuYN+IrAA=",
+        "identification_txid": "bb32395f8e351572b8eb1432ba664cca2f9346b3734e80eff2fec33e28c18e5e",
+        "tx_modifiable": 1
+      },
+      {
+        "name": "user-signed",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEBBgEBAAEOIAOemco6/ra8aNcan5VF7DZxq2F983TeOQdh7zLLh/AhAQ8EAAAAAAEAeAEAAAAB8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fEAAAAAAP////8BZAAAAAAAAAA8IcG9w17HI5C1Eo8TgwH62RMp8X1FqzHUOvo96iBvKlobwLx2qRQUwl0sXrckijhB90107+O0Bjs4P4isAAAAAAEDBIEAAAAiBgLf5lkOudxWLYcnL+Ekj2Pp7Szj6yh5/O8wrj6ScgssyRjwVlWsLAAAgEkJAIAAAACAAAAAAAAAAAAiAgLf5lkOudxWLYcnL+Ekj2Pp7Szj6yh5/O8wrj6ScgssyUgwRQIhAKsYyZGL2mRtx4F1QN35om0GC8J20wfoal7w5gHqs2rUAiAkK4fEunyN463N/WiFJ9RqVSnzZaFfVwtuypx4mQ5+G4EAAQMIZAAAAAAAAAABBDwhwb3DXscjkLUSjxODAfrZEynxfUWrMdQ6+j3qIG8qWhvAvHapFFcaKS3BG7RxcDDwTVZFrELyrmDfiKwA",
+        "identification_txid": "bb32395f8e351572b8eb1432ba664cca2f9346b3734e80eff2fec33e28c18e5e",
+        "tx_modifiable": 1
+      },
+      {
+        "name": "provider-added-input",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAgEFAQEBBgEBAAEOIAOemco6/ra8aNcan5VF7DZxq2F983TeOQdh7zLLh/AhAQ8EAAAAAAEAeAEAAAAB8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fEAAAAAAP////8BZAAAAAAAAAA8IcG9w17HI5C1Eo8TgwH62RMp8X1FqzHUOvo96iBvKlobwLx2qRQUwl0sXrckijhB90107+O0Bjs4P4isAAAAAAEDBIEAAAAiBgLf5lkOudxWLYcnL+Ekj2Pp7Szj6yh5/O8wrj6ScgssyRjwVlWsLAAAgEkJAIAAAACAAAAAAAAAAAAiAgLf5lkOudxWLYcnL+Ekj2Pp7Szj6yh5/O8wrj6ScgssyUgwRQIhAKsYyZGL2mRtx4F1QN35om0GC8J20wfoal7w5gHqs2rUAiAkK4fEunyN463N/WiFJ9RqVSnzZaFfVwtuypx4mQ5+G4EAAQ4gi7aNx87XGuA6v/+z6UcGmjaQVtwpjke/skKK8pvs9l0BDwQAAAAAAAEDCGQAAAAAAAAAAQQ8IcG9w17HI5C1Eo8TgwH62RMp8X1FqzHUOvo96iBvKlobwLx2qRRXGiktwRu0cXAw8E1WRaxC8q5g34isAA==",
+        "identification_txid": "e4c1f43399af0cf7b7d895c09f26a5ed3a6ea60249c83b5e66e6ab27e4f7c13a",
+        "tx_modifiable": 1
+      },
+      {
+        "name": "provider-signed",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAgEFAQEBBgEAAAEOIAOemco6/ra8aNcan5VF7DZxq2F983TeOQdh7zLLh/AhAQ8EAAAAAAEAeAEAAAAB8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fEAAAAAAP////8BZAAAAAAAAAA8IcG9w17HI5C1Eo8TgwH62RMp8X1FqzHUOvo96iBvKlobwLx2qRQUwl0sXrckijhB90107+O0Bjs4P4isAAAAAAEDBIEAAAAiBgLf5lkOudxWLYcnL+Ekj2Pp7Szj6yh5/O8wrj6ScgssyRjwVlWsLAAAgEkJAIAAAACAAAAAAAAAAAAiAgLf5lkOudxWLYcnL+Ekj2Pp7Szj6yh5/O8wrj6ScgssyUgwRQIhAKsYyZGL2mRtx4F1QN35om0GC8J20wfoal7w5gHqs2rUAiAkK4fEunyN463N/WiFJ9RqVSnzZaFfVwtuypx4mQ5+G4EAAQ4gi7aNx87XGuA6v/+z6UcGmjaQVtwpjke/skKK8pvs9l0BDwQAAAAAAQBVAQAAAAHy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8gAAAAAA/////wHoAwAAAAAAABl2qRTcrH2ExoRMgvcVgCqDTFZxvcWCEoisAAAAACIGAwMMmt+dqqUNF5wE/Baj+/eYXjICE0NoAwCipRH0LANBGPBWVawsAACASQkAgAAAAIAAAAAABQAAACICAwMMmt+dqqUNF5wE/Baj+/eYXjICE0NoAwCipRH0LANBSDBFAiEAuMxPEZ4NeDsJXWaHdFAR8Ws2mmZ9lNnUGkcvkajRXuoCIGU1dLWwJUOfDJN8YF69ZUEHaFmrbKcUGsWSudyrY9rZAQABAwhkAAAAAAAAAAEEPCHBvcNexyOQtRKPE4MB+tkTKfF9Rasx1Dr6PeogbypaG8C8dqkUVxopLcEbtHFwMPBNVkWsQvKuYN+IrAA=",
+        "identification_txid": "e4c1f43399af0cf7b7d895c09f26a5ed3a6ea60249c83b5e66e6ab27e4f7c13a",
+        "tx_modifiable": 0
+      },
+      {
+        "name": "finalized",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAgEFAQEBBgEAAAEOIAOemco6/ra8aNcan5VF7DZxq2F983TeOQdh7zLLh/AhAQ8EAAAAAAEAeAEAAAAB8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fEAAAAAAP////8BZAAAAAAAAAA8IcG9w17HI5C1Eo8TgwH62RMp8X1FqzHUOvo96iBvKlobwLx2qRQUwl0sXrckijhB90107+O0Bjs4P4isAAAAAAEHa0gwRQIhAKsYyZGL2mRtx4F1QN35om0GC8J20wfoal7w5gHqs2rUAiAkK4fEunyN463N/WiFJ9RqVSnzZaFfVwtuypx4mQ5+G4EhAt/mWQ653FYthycv4SSPY+ntLOPrKHn87zCuPpJyCyzJAAEOIIu2jcfO1xrgOr//s+lHBpo2kFbcKY5Hv7JCivKb7PZdAQ8EAAAAAAEAVQEAAAAB8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vIAAAAAAP////8B6AMAAAAAAAAZdqkU3Kx9hMaETIL3FYAqg0xWcb3FghKIrAAAAAABB2tIMEUCIQC4zE8Rng14OwldZod0UBHxazaaZn2U2dQaRy+RqNFe6gIgZTV0tbAlQ58Mk3xgXr1lQQdoWatspxQaxZK53Ktj2tkBIQMDDJrfnaqlDRecBPwWo/v3mF4yAhNDaAMAoqUR9CwDQQABAwhkAAAAAAAAAAEEPCHBvcNexyOQtRKPE4MB+tkTKfF9Rasx1Dr6PeogbypaG8C8dqkUVxopLcEbtHFwMPBNVkWsQvKuYN+IrAA=",
+        "identification_txid": "e4c1f43399af0cf7b7d895c09f26a5ed3a6ea60249c83b5e66e6ab27e4f7c13a",
+        "tx_modifiable": 0
+      }
+    ],
+    "extracted_tx": "0100000002039e99ca3afeb6bc68d71a9f9545ec3671ab617df374de390761ef32cb87f021000000006b483045022100ab18c9918bda646dc7817540ddf9a26d060bc276d307e86a5ef0e601eab36ad40220242b87c4ba7c8de3adcdfd688527d46a5529f365a15f570b6eca9c78990e7e1b812102dfe6590eb9dc562d87272fe1248f63e9ed2ce3eb2879fcef30ae3e92720b2cc9ffffffff8bb68dc7ced71ae03abfffb3e947069a369056dc298e47bfb2428af29becf65d000000006b483045022100b8cc4f119e0d783b095d6687745011f16b369a667d94d9d41a472f91a8d15eea0220653574b5b025439f0c937c605ebd6541076859ab6ca7141ac592b9dcab63dad9012103030c9adf9daaa50d179c04fc16a3fbf7985e32021343680300a2a511f42c0341ffffffff0164000000000000003c21c1bdc35ec72390b5128f138301fad91329f17d45ab31d43afa3dea206f2a5a1bc0bc76a914571a292dc11bb4717030f04d5645ac42f2ae60df88ac00000000",
+    "final_txid": "4266397ab1b64bc2ef2988c3e98566447e10e0265657bb27bfd94ac343c0b140"
+  },
+  {
+    "id": "fee-provider-interactive",
+    "description": "Fee provider workflow, interactive variant (with change output). The user sends an unsigned 100-token CP2PKH transfer with both modifiable flags set. The provider, acting as Constructor, adds a 20000-tapy P2PKH fee input and a 19000-tapy change output (fee 1000), attaches its input's UTXO, and clears both flags to declare construction finished. Both parties then sign with SIGHASH_ALL, finalize, and extract.",
+    "intermediates": [
+      {
+        "input": 0,
+        "pubkey": "02dfe6590eb9dc562d87272fe1248f63e9ed2ce3eb2879fcef30ae3e92720b2cc9",
+        "sighash_type": 1,
+        "script_code": "21c1bdc35ec72390b5128f138301fad91329f17d45ab31d43afa3dea206f2a5a1bc0bc76a91414c25d2c5eb7248a3841f74d74efe3b4063b383f88ac",
+        "sighash": "0dd82b63fe177415da9f800a05e375c0fc18847183989673d8e77dc596e6d860",
+        "signature": "3045022100914efefa503aeab2aac785328f475463f86ee41669287c802b61e939d097033102202bedaed2e3b3008827dd61bee610d2e6f6a5ee265ff06f1b17aa52080807c4fa01"
+      },
+      {
+        "input": 1,
+        "pubkey": "03030c9adf9daaa50d179c04fc16a3fbf7985e32021343680300a2a511f42c0341",
+        "sighash_type": 1,
+        "script_code": "76a914dcac7d84c6844c82f715802a834c5671bdc5821288ac",
+        "sighash": "f822b1b4621a4281bfd843918b9f8f86543dfcb46cc2c155a735d1ae2e89e6ca",
+        "signature": "3044022071ee759ea4df8c39e7799999f958e8e9474c6d87caaa6d3cd6899c40930aadeb02200aad507220232e074d5caefabba138e5995e58dc54087e914e5715ee4eb57feb01"
+      }
+    ],
+    "stages": [
+      {
+        "name": "user-constructed",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEBBgEDAAEOIPxomTHBQJdE34WoWglGI66Tn86zIxCX9nvPIMS7uUveAQ8EAAAAAAABAwhkAAAAAAAAAAEEPCHBvcNexyOQtRKPE4MB+tkTKfF9Rasx1Dr6PeogbypaG8C8dqkUVxopLcEbtHFwMPBNVkWsQvKuYN+IrAA=",
+        "identification_txid": "18bdedafe492235e4b0f5a774d1e7317f41536b4eec6427be90113a1f47e363e",
+        "tx_modifiable": 3
+      },
+      {
+        "name": "provider-constructed",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAgEFAQIBBgEAAAEOIPxomTHBQJdE34WoWglGI66Tn86zIxCX9nvPIMS7uUveAQ8EAAAAAAABDiCqTkoBOxybnOO2CwnW40rwLnOat8xXG5CBuVp8/xrxhgEPBAAAAAABAFUBAAAAAfPz8/Pz8/Pz8/Pz8/Pz8/Pz8/Pz8/Pz8/Pz8/Pz8/PzAAAAAAD/////ASBOAAAAAAAAGXapFNysfYTGhEyC9xWAKoNMVnG9xYISiKwAAAAAAAEDCGQAAAAAAAAAAQQ8IcG9w17HI5C1Eo8TgwH62RMp8X1FqzHUOvo96iBvKlobwLx2qRRXGiktwRu0cXAw8E1WRaxC8q5g34isAAEDCDhKAAAAAAAAAQQZdqkUNs1RHDntnYJbTbzDWNm0liyQp0WIrCICArDrs/3AwNduzz2Bk5by9oZGwyYeHL2quM3iYPlIRc5yGPBWVawsAACASQkAgAAAAIAAAAAABgAAAAA=",
+        "identification_txid": "f5b31c17e398a2be443d9c79cbe9bfeb41b835fcaa03aca6a841cdc813f74a96",
+        "tx_modifiable": 0
+      },
+      {
+        "name": "signed",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAgEFAQIBBgEAAAEOIPxomTHBQJdE34WoWglGI66Tn86zIxCX9nvPIMS7uUveAQ8EAAAAAAEAeAEAAAAB9PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PQAAAAAAP////8BZAAAAAAAAAA8IcG9w17HI5C1Eo8TgwH62RMp8X1FqzHUOvo96iBvKlobwLx2qRQUwl0sXrckijhB90107+O0Bjs4P4isAAAAACIGAt/mWQ653FYthycv4SSPY+ntLOPrKHn87zCuPpJyCyzJGPBWVawsAACASQkAgAAAAIAAAAAAAAAAACICAt/mWQ653FYthycv4SSPY+ntLOPrKHn87zCuPpJyCyzJSDBFAiEAkU7++lA66rKqx4Uyj0dUY/hu5BZpKHyAK2HpOdCXAzECICvtrtLjswCIJ91hvuYQ0ub2pe4mX/BvGxeqUggIB8T6AQABDiCqTkoBOxybnOO2CwnW40rwLnOat8xXG5CBuVp8/xrxhgEPBAAAAAABAFUBAAAAAfPz8/Pz8/Pz8/Pz8/Pz8/Pz8/Pz8/Pz8/Pz8/Pz8/PzAAAAAAD/////ASBOAAAAAAAAGXapFNysfYTGhEyC9xWAKoNMVnG9xYISiKwAAAAAIgYDAwya352qpQ0XnAT8FqP795heMgITQ2gDAKKlEfQsA0EY8FZVrCwAAIBJCQCAAAAAgAAAAAAFAAAAIgIDAwya352qpQ0XnAT8FqP795heMgITQ2gDAKKlEfQsA0FHMEQCIHHudZ6k34w553mZmflY6OlHTG2HyqptPNaJnECTCq3rAiAKrVByICMuB01crvq7oTjlmV5Y3FQIfpFOVxXuTrV/6wEAAQMIZAAAAAAAAAABBDwhwb3DXscjkLUSjxODAfrZEynxfUWrMdQ6+j3qIG8qWhvAvHapFFcaKS3BG7RxcDDwTVZFrELyrmDfiKwAAQMIOEoAAAAAAAABBBl2qRQ2zVEcOe2dgltNvMNY2bSWLJCnRYisIgICsOuz/cDA127PPYGTlvL2hkbDJh4cvaq4zeJg+UhFznIY8FZVrCwAAIBJCQCAAAAAgAAAAAAGAAAAAA==",
+        "identification_txid": "f5b31c17e398a2be443d9c79cbe9bfeb41b835fcaa03aca6a841cdc813f74a96",
+        "tx_modifiable": 0
+      },
+      {
+        "name": "finalized",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAgEFAQIBBgEAAAEOIPxomTHBQJdE34WoWglGI66Tn86zIxCX9nvPIMS7uUveAQ8EAAAAAAEAeAEAAAAB9PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PQAAAAAAP////8BZAAAAAAAAAA8IcG9w17HI5C1Eo8TgwH62RMp8X1FqzHUOvo96iBvKlobwLx2qRQUwl0sXrckijhB90107+O0Bjs4P4isAAAAAAEHa0gwRQIhAJFO/vpQOuqyqseFMo9HVGP4buQWaSh8gCth6TnQlwMxAiAr7a7S47MAiCfdYb7mENLm9qXuJl/wbxsXqlIICAfE+gEhAt/mWQ653FYthycv4SSPY+ntLOPrKHn87zCuPpJyCyzJAAEOIKpOSgE7HJuc47YLCdbjSvAuc5q3zFcbkIG5Wnz/GvGGAQ8EAAAAAAEAVQEAAAAB8/Pz8/Pz8/Pz8/Pz8/Pz8/Pz8/Pz8/Pz8/Pz8/Pz8/MAAAAAAP////8BIE4AAAAAAAAZdqkU3Kx9hMaETIL3FYAqg0xWcb3FghKIrAAAAAABB2pHMEQCIHHudZ6k34w553mZmflY6OlHTG2HyqptPNaJnECTCq3rAiAKrVByICMuB01crvq7oTjlmV5Y3FQIfpFOVxXuTrV/6wEhAwMMmt+dqqUNF5wE/Baj+/eYXjICE0NoAwCipRH0LANBAAEDCGQAAAAAAAAAAQQ8IcG9w17HI5C1Eo8TgwH62RMp8X1FqzHUOvo96iBvKlobwLx2qRRXGiktwRu0cXAw8E1WRaxC8q5g34isAAEDCDhKAAAAAAAAAQQZdqkUNs1RHDntnYJbTbzDWNm0liyQp0WIrCICArDrs/3AwNduzz2Bk5by9oZGwyYeHL2quM3iYPlIRc5yGPBWVawsAACASQkAgAAAAIAAAAAABgAAAAA=",
+        "identification_txid": "f5b31c17e398a2be443d9c79cbe9bfeb41b835fcaa03aca6a841cdc813f74a96",
+        "tx_modifiable": 0
+      }
+    ],
+    "extracted_tx": "0100000002fc689931c1409744df85a85a094623ae939fceb3231097f67bcf20c4bbb94bde000000006b483045022100914efefa503aeab2aac785328f475463f86ee41669287c802b61e939d097033102202bedaed2e3b3008827dd61bee610d2e6f6a5ee265ff06f1b17aa52080807c4fa012102dfe6590eb9dc562d87272fe1248f63e9ed2ce3eb2879fcef30ae3e92720b2cc9ffffffffaa4e4a013b1c9b9ce3b60b09d6e34af02e739ab7cc571b9081b95a7cff1af186000000006a473044022071ee759ea4df8c39e7799999f958e8e9474c6d87caaa6d3cd6899c40930aadeb02200aad507220232e074d5caefabba138e5995e58dc54087e914e5715ee4eb57feb012103030c9adf9daaa50d179c04fc16a3fbf7985e32021343680300a2a511f42c0341ffffffff0264000000000000003c21c1bdc35ec72390b5128f138301fad91329f17d45ab31d43afa3dea206f2a5a1bc0bc76a914571a292dc11bb4717030f04d5645ac42f2ae60df88ac384a0000000000001976a91436cd511c39ed9d825b4dbcc358d9b4962c90a74588ac00000000",
+    "final_txid": "ef4b6a8521e3d009ffe5973c3b1b88b6a97233b32c86e82fbd2d4dc62ecabcf8"
+  },
+  {
+    "id": "locktime-height",
+    "description": "A single input requires a height-based locktime (PSTT_IN_REQUIRED_HEIGHT_LOCKTIME = 680000) and no other input specifies a locktime, so the transaction locktime is 680000 (Determining the Locktime, \"one input specifies a required locktime, of one kind\").",
+    "intermediates": [
+      {
+        "input": 0,
+        "pubkey": "02dfe6590eb9dc562d87272fe1248f63e9ed2ce3eb2879fcef30ae3e92720b2cc9",
+        "sighash_type": 1,
+        "script_code": "76a91414c25d2c5eb7248a3841f74d74efe3b4063b383f88ac",
+        "sighash": "d5549d43f566aeb6292d20132f716f6018d84c8a8f08e686bc9404d8ba149aa6",
+        "signature": "304402205da95d3ffde07abca5bd3e281d640199a582acb14bbe96991538f1be4fdab6ac022003a3ede7b8ea487aa2fb16a076c098272c57b5183aaf4bb82419a12c9985df7201"
+      }
+    ],
+    "stages": [
+      {
+        "name": "created",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEAAQ4gp484ZYW5tiVwtzMps/ieUH6KIs1PxO/VGcfgPibQtHQBDwQAAAAAARIEQGAKAAABAwi4ggEAAAAAAAEEGXapFFcaKS3BG7RxcDDwTVZFrELyrmDfiKwA",
+        "identification_txid": "10260e3511b4c6401e54108f63f0bfe4cbad569db24d6af9c2f6ea3a502d599e"
+      },
+      {
+        "name": "updated",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEAAQ4gp484ZYW5tiVwtzMps/ieUH6KIs1PxO/VGcfgPibQtHQBDwQAAAAAAQBVAQAAAAH29vb29vb29vb29vb29vb29vb29vb29vb29vb29vb29gAAAAAA/////wGghgEAAAAAABl2qRQUwl0sXrckijhB90107+O0Bjs4P4isAAAAAAEDBAEAAAAiBgLf5lkOudxWLYcnL+Ekj2Pp7Szj6yh5/O8wrj6ScgssyRjwVlWsLAAAgEkJAIAAAACAAAAAAAAAAAABEgRAYAoAAAEDCLiCAQAAAAAAAQQZdqkUVxopLcEbtHFwMPBNVkWsQvKuYN+IrAA=",
+        "identification_txid": "10260e3511b4c6401e54108f63f0bfe4cbad569db24d6af9c2f6ea3a502d599e"
+      },
+      {
+        "name": "signed",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEAAQ4gp484ZYW5tiVwtzMps/ieUH6KIs1PxO/VGcfgPibQtHQBDwQAAAAAAQBVAQAAAAH29vb29vb29vb29vb29vb29vb29vb29vb29vb29vb29gAAAAAA/////wGghgEAAAAAABl2qRQUwl0sXrckijhB90107+O0Bjs4P4isAAAAAAEDBAEAAAAiBgLf5lkOudxWLYcnL+Ekj2Pp7Szj6yh5/O8wrj6ScgssyRjwVlWsLAAAgEkJAIAAAACAAAAAAAAAAAABEgRAYAoAIgIC3+ZZDrncVi2HJy/hJI9j6e0s4+soefzvMK4+knILLMlHMEQCIF2pXT/94Hq8pb0+KB1kAZmlgqyxS76WmRU48b5P2rasAiADo+3nuOpIeqL7FqB2wJgnLFe1GDqvS7gkGaEsmYXfcgEAAQMIuIIBAAAAAAABBBl2qRRXGiktwRu0cXAw8E1WRaxC8q5g34isAA==",
+        "identification_txid": "10260e3511b4c6401e54108f63f0bfe4cbad569db24d6af9c2f6ea3a502d599e"
+      },
+      {
+        "name": "finalized",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEAAQ4gp484ZYW5tiVwtzMps/ieUH6KIs1PxO/VGcfgPibQtHQBDwQAAAAAAQBVAQAAAAH29vb29vb29vb29vb29vb29vb29vb29vb29vb29vb29gAAAAAA/////wGghgEAAAAAABl2qRQUwl0sXrckijhB90107+O0Bjs4P4isAAAAAAESBEBgCgABB2pHMEQCIF2pXT/94Hq8pb0+KB1kAZmlgqyxS76WmRU48b5P2rasAiADo+3nuOpIeqL7FqB2wJgnLFe1GDqvS7gkGaEsmYXfcgEhAt/mWQ653FYthycv4SSPY+ntLOPrKHn87zCuPpJyCyzJAAEDCLiCAQAAAAAAAQQZdqkUVxopLcEbtHFwMPBNVkWsQvKuYN+IrAA=",
+        "identification_txid": "10260e3511b4c6401e54108f63f0bfe4cbad569db24d6af9c2f6ea3a502d599e"
+      }
+    ],
+    "extracted_tx": "0100000001a78f386585b9b62570b73329b3f89e507e8a22cd4fc4efd519c7e03e26d0b474000000006a47304402205da95d3ffde07abca5bd3e281d640199a582acb14bbe96991538f1be4fdab6ac022003a3ede7b8ea487aa2fb16a076c098272c57b5183aaf4bb82419a12c9985df72012102dfe6590eb9dc562d87272fe1248f63e9ed2ce3eb2879fcef30ae3e92720b2cc9ffffffff01b8820100000000001976a914571a292dc11bb4717030f04d5645ac42f2ae60df88ac40600a00",
+    "final_txid": "075de6144189adb4b09fa28f710f810974059c6aeb1212512046a2b48c7d0a1e"
+  },
+  {
+    "id": "locktime-time",
+    "description": "A single input requires a time-based locktime (PSTT_IN_REQUIRED_TIME_LOCKTIME = 1700000000, a Unix timestamp) and no other input specifies a locktime, so the transaction locktime is 1700000000.",
+    "intermediates": [
+      {
+        "input": 0,
+        "pubkey": "02dfe6590eb9dc562d87272fe1248f63e9ed2ce3eb2879fcef30ae3e92720b2cc9",
+        "sighash_type": 1,
+        "script_code": "76a91414c25d2c5eb7248a3841f74d74efe3b4063b383f88ac",
+        "sighash": "12ec77370034bd2f6d406007f2f5ccdb076431cf78e7d937f357708816aa6b58",
+        "signature": "3045022100d5ece9b63757ffb2b24d99b6265201b4db95517606a0ff654eb187e3e8062e8b02203db506e32abe48a41611564909aa2d6a54f08eec320868fdb63eb24a7e843fec01"
+      }
+    ],
+    "stages": [
+      {
+        "name": "created",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEAAQ4gp484ZYW5tiVwtzMps/ieUH6KIs1PxO/VGcfgPibQtHQBDwQAAAAAAREEAPFTZQABAwi4ggEAAAAAAAEEGXapFFcaKS3BG7RxcDDwTVZFrELyrmDfiKwA",
+        "identification_txid": "112cb6bd9b60f20f899b6322007c9e252729d07e8d838954bfd439bf5edbdb43"
+      },
+      {
+        "name": "updated",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEAAQ4gp484ZYW5tiVwtzMps/ieUH6KIs1PxO/VGcfgPibQtHQBDwQAAAAAAQBVAQAAAAH29vb29vb29vb29vb29vb29vb29vb29vb29vb29vb29gAAAAAA/////wGghgEAAAAAABl2qRQUwl0sXrckijhB90107+O0Bjs4P4isAAAAAAEDBAEAAAAiBgLf5lkOudxWLYcnL+Ekj2Pp7Szj6yh5/O8wrj6ScgssyRjwVlWsLAAAgEkJAIAAAACAAAAAAAAAAAABEQQA8VNlAAEDCLiCAQAAAAAAAQQZdqkUVxopLcEbtHFwMPBNVkWsQvKuYN+IrAA=",
+        "identification_txid": "112cb6bd9b60f20f899b6322007c9e252729d07e8d838954bfd439bf5edbdb43"
+      },
+      {
+        "name": "signed",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEAAQ4gp484ZYW5tiVwtzMps/ieUH6KIs1PxO/VGcfgPibQtHQBDwQAAAAAAQBVAQAAAAH29vb29vb29vb29vb29vb29vb29vb29vb29vb29vb29gAAAAAA/////wGghgEAAAAAABl2qRQUwl0sXrckijhB90107+O0Bjs4P4isAAAAAAEDBAEAAAAiBgLf5lkOudxWLYcnL+Ekj2Pp7Szj6yh5/O8wrj6ScgssyRjwVlWsLAAAgEkJAIAAAACAAAAAAAAAAAABEQQA8VNlIgIC3+ZZDrncVi2HJy/hJI9j6e0s4+soefzvMK4+knILLMlIMEUCIQDV7Om2N1f/srJNmbYmUgG025VRdgag/2VOsYfj6AYuiwIgPbUG4yq+SKQWEVZJCaotalTwjuwyCGj9tj6ySn6EP+wBAAEDCLiCAQAAAAAAAQQZdqkUVxopLcEbtHFwMPBNVkWsQvKuYN+IrAA=",
+        "identification_txid": "112cb6bd9b60f20f899b6322007c9e252729d07e8d838954bfd439bf5edbdb43"
+      },
+      {
+        "name": "finalized",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEAAQ4gp484ZYW5tiVwtzMps/ieUH6KIs1PxO/VGcfgPibQtHQBDwQAAAAAAQBVAQAAAAH29vb29vb29vb29vb29vb29vb29vb29vb29vb29vb29gAAAAAA/////wGghgEAAAAAABl2qRQUwl0sXrckijhB90107+O0Bjs4P4isAAAAAAERBADxU2UBB2tIMEUCIQDV7Om2N1f/srJNmbYmUgG025VRdgag/2VOsYfj6AYuiwIgPbUG4yq+SKQWEVZJCaotalTwjuwyCGj9tj6ySn6EP+wBIQLf5lkOudxWLYcnL+Ekj2Pp7Szj6yh5/O8wrj6ScgssyQABAwi4ggEAAAAAAAEEGXapFFcaKS3BG7RxcDDwTVZFrELyrmDfiKwA",
+        "identification_txid": "112cb6bd9b60f20f899b6322007c9e252729d07e8d838954bfd439bf5edbdb43"
+      }
+    ],
+    "extracted_tx": "0100000001a78f386585b9b62570b73329b3f89e507e8a22cd4fc4efd519c7e03e26d0b474000000006b483045022100d5ece9b63757ffb2b24d99b6265201b4db95517606a0ff654eb187e3e8062e8b02203db506e32abe48a41611564909aa2d6a54f08eec320868fdb63eb24a7e843fec012102dfe6590eb9dc562d87272fe1248f63e9ed2ce3eb2879fcef30ae3e92720b2cc9ffffffff01b8820100000000001976a914571a292dc11bb4717030f04d5645ac42f2ae60df88ac00f15365",
+    "final_txid": "4a9f5bf3bd0999b22afeb9429bc02016562f5fff8c3682e45b819f584deba994"
+  },
+  {
+    "id": "locktime-fallback",
+    "description": "No input specifies a required locktime, but PSTT_GLOBAL_FALLBACK_LOCKTIME is 500, so the transaction locktime is 500 rather than the default of 0.",
+    "intermediates": [
+      {
+        "input": 0,
+        "pubkey": "02dfe6590eb9dc562d87272fe1248f63e9ed2ce3eb2879fcef30ae3e92720b2cc9",
+        "sighash_type": 1,
+        "script_code": "76a91414c25d2c5eb7248a3841f74d74efe3b4063b383f88ac",
+        "sighash": "5123c2f38c4ee4390e0d00d30b0bef3107e081a998abb09175a7b1f8dcc1a51f",
+        "signature": "3045022100ec502dda0d6972e9410ebb4b288d2e82aab2e8380d28775bc43da5129191618302203d71baff364054634a573446a0a59d7b08c90fbd62cf3b7b3a44848523592e6e01"
+      }
+    ],
+    "stages": [
+      {
+        "name": "created",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEBAwT0AQAAAAEOIKePOGWFubYlcLczKbP4nlB+iiLNT8Tv1RnH4D4m0LR0AQ8EAAAAAAABAwi4ggEAAAAAAAEEGXapFFcaKS3BG7RxcDDwTVZFrELyrmDfiKwA",
+        "identification_txid": "5e07461667147a6bf46ed4ab8c3fac9693b9ce5e2183fb481a1d2dd461ab8f9c"
+      },
+      {
+        "name": "updated",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEBAwT0AQAAAAEOIKePOGWFubYlcLczKbP4nlB+iiLNT8Tv1RnH4D4m0LR0AQ8EAAAAAAEAVQEAAAAB9vb29vb29vb29vb29vb29vb29vb29vb29vb29vb29vYAAAAAAP////8BoIYBAAAAAAAZdqkUFMJdLF63JIo4QfdNdO/jtAY7OD+IrAAAAAABAwQBAAAAIgYC3+ZZDrncVi2HJy/hJI9j6e0s4+soefzvMK4+knILLMkY8FZVrCwAAIBJCQCAAAAAgAAAAAAAAAAAAAEDCLiCAQAAAAAAAQQZdqkUVxopLcEbtHFwMPBNVkWsQvKuYN+IrAA=",
+        "identification_txid": "5e07461667147a6bf46ed4ab8c3fac9693b9ce5e2183fb481a1d2dd461ab8f9c"
+      },
+      {
+        "name": "signed",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEBAwT0AQAAAAEOIKePOGWFubYlcLczKbP4nlB+iiLNT8Tv1RnH4D4m0LR0AQ8EAAAAAAEAVQEAAAAB9vb29vb29vb29vb29vb29vb29vb29vb29vb29vb29vYAAAAAAP////8BoIYBAAAAAAAZdqkUFMJdLF63JIo4QfdNdO/jtAY7OD+IrAAAAAABAwQBAAAAIgYC3+ZZDrncVi2HJy/hJI9j6e0s4+soefzvMK4+knILLMkY8FZVrCwAAIBJCQCAAAAAgAAAAAAAAAAAIgIC3+ZZDrncVi2HJy/hJI9j6e0s4+soefzvMK4+knILLMlIMEUCIQDsUC3aDWly6UEOu0sojS6CqrLoOA0od1vEPaUSkZFhgwIgPXG6/zZAVGNKVzRGoKWdewjJD71izzt7OkSEhSNZLm4BAAEDCLiCAQAAAAAAAQQZdqkUVxopLcEbtHFwMPBNVkWsQvKuYN+IrAA=",
+        "identification_txid": "5e07461667147a6bf46ed4ab8c3fac9693b9ce5e2183fb481a1d2dd461ab8f9c"
+      },
+      {
+        "name": "finalized",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEBAwT0AQAAAAEOIKePOGWFubYlcLczKbP4nlB+iiLNT8Tv1RnH4D4m0LR0AQ8EAAAAAAEAVQEAAAAB9vb29vb29vb29vb29vb29vb29vb29vb29vb29vb29vYAAAAAAP////8BoIYBAAAAAAAZdqkUFMJdLF63JIo4QfdNdO/jtAY7OD+IrAAAAAABB2tIMEUCIQDsUC3aDWly6UEOu0sojS6CqrLoOA0od1vEPaUSkZFhgwIgPXG6/zZAVGNKVzRGoKWdewjJD71izzt7OkSEhSNZLm4BIQLf5lkOudxWLYcnL+Ekj2Pp7Szj6yh5/O8wrj6ScgssyQABAwi4ggEAAAAAAAEEGXapFFcaKS3BG7RxcDDwTVZFrELyrmDfiKwA",
+        "identification_txid": "5e07461667147a6bf46ed4ab8c3fac9693b9ce5e2183fb481a1d2dd461ab8f9c"
+      }
+    ],
+    "extracted_tx": "0100000001a78f386585b9b62570b73329b3f89e507e8a22cd4fc4efd519c7e03e26d0b474000000006b483045022100ec502dda0d6972e9410ebb4b288d2e82aab2e8380d28775bc43da5129191618302203d71baff364054634a573446a0a59d7b08c90fbd62cf3b7b3a44848523592e6e012102dfe6590eb9dc562d87272fe1248f63e9ed2ce3eb2879fcef30ae3e92720b2cc9ffffffff01b8820100000000001976a914571a292dc11bb4717030f04d5645ac42f2ae60df88acf4010000",
+    "final_txid": "38d4defaf8d239cc6923439d952b6f38a61d3909299f0f43adef32e9e8527719"
+  }
+]

--- a/spec/schnorr_spec.rb
+++ b/spec/schnorr_spec.rb
@@ -16,6 +16,35 @@ describe Schnorr do
     end
   end
 
+  describe "deterministic nonce" do
+    # Known answers taken from the deterministic signature test of tapyrus-core
+    # (src/test/key_tests.cpp), which exercises secp256k1_schnorr_sign, the path a node actually
+    # signs with. Verifying a signature does not depend on how its nonce was derived, so a
+    # sign-then-verify test cannot detect a wrong RFC 6979 algorithm tag. Only these vectors can.
+    let(:message) { Tapyrus.double_sha256("Very deterministic message") }
+
+    it "reproduces the signatures tapyrus-core produces" do
+      [
+        # strSecret1 (5HxWvvfubhXpYYpS3tJkw6fq9jE9j18THftkZjHHfmFiWtmAbrj)
+        [
+          "12b004fff7f4b69ef8650e767f18f11ede158148b425660723b9f9a66e61f747",
+          "0567cbade8656cff3bb08d00913d59363273c32ea66130cf0c9b1be8e874b8bc" \
+            "b0e62372c22e8ecd34ffeadda493beb221e52bf23413cc6c3abdcdfc03d0ed52"
+        ],
+        # strSecret2 (5KC4ejrDjv152FGwP386VD1i2NYc5KkfSMyv1nGy1VGDxGHqVY3)
+        [
+          "b524c28b61c9b2c49b2c7dd4c2d75887abb78768c054bd7c01af4029f6c0d117",
+          "064623e23b59e1bd304156fb20c197eee23e6d10e021664aef3878364d9d5e17" \
+            "5916f7909c9358192e9c1510ebb466b085e726aab0d71c6ef9f298b53ea179aa"
+        ]
+      ].each do |priv, expected|
+        key = Tapyrus::Key.new(priv_key: priv)
+        expect(key.sign(message, algo: :schnorr).bth).to eq(expected)
+        expect(Schnorr.sign(message, priv.to_i(16)).encode.bth).to eq(expected)
+      end
+    end
+  end
+
   describe "compact schnorr" do
     it "should be passed." do
       # Test Vector 1

--- a/spec/tapyrus/key_path_spec.rb
+++ b/spec/tapyrus/key_path_spec.rb
@@ -1,0 +1,60 @@
+require "spec_helper"
+
+describe Tapyrus::KeyPath do
+  let(:test_class) { Struct.new(:key_path) { include Tapyrus::KeyPath } }
+  let(:subject) { test_class.new }
+
+  describe "#parse_key_path" do
+    it "should parse a path" do
+      expect(subject.parse_key_path("m")).to eq([])
+      expect(subject.parse_key_path("m/0")).to eq([0])
+      expect(subject.parse_key_path("m/0'")).to eq([2_147_483_648])
+      expect(subject.parse_key_path("m/44'/2377'/0'/0/0")).to eq([2_147_483_692, 2_147_486_025, 2_147_483_648, 0, 0])
+      expect(subject.parse_key_path("m/2147483647'")).to eq([4_294_967_295])
+    end
+
+    it "should reject a path which does not begin with m" do
+      expect { subject.parse_key_path("") }.to raise_error(ArgumentError, " is invalid format.")
+      expect { subject.parse_key_path("0/1") }.to raise_error(ArgumentError, "0/1 is invalid format.")
+      expect { subject.parse_key_path("n/0") }.to raise_error(ArgumentError, "n/0 is invalid format.")
+    end
+
+    it "should reject an element which is not a decimal index" do
+      expect { subject.parse_key_path("m/1abc") }.to raise_error(ArgumentError, "m/1abc is invalid format.")
+      expect { subject.parse_key_path("m/1abc'") }.to raise_error(ArgumentError, "m/1abc' is invalid format.")
+      expect { subject.parse_key_path("m/-1") }.to raise_error(ArgumentError, "m/-1 is invalid format.")
+      expect { subject.parse_key_path("m/ 1") }.to raise_error(ArgumentError, "m/ 1 is invalid format.")
+    end
+
+    # String#to_i stops at the first character which is not a digit, so an element which carries
+    # the hardened marker anywhere but at its end must be rejected before it is converted.
+    it "should reject an element whose hardened marker is misplaced" do
+      expect { subject.parse_key_path("m/1'2") }.to raise_error(ArgumentError, "m/1'2 is invalid format.")
+      expect { subject.parse_key_path("m/12''") }.to raise_error(ArgumentError, "m/12'' is invalid format.")
+      expect { subject.parse_key_path("m/'12") }.to raise_error(ArgumentError, "m/'12 is invalid format.")
+    end
+
+    it "should reject an index which has no representation in this notation" do
+      expect { subject.parse_key_path("m/2147483648") }.to raise_error(ArgumentError, "m/2147483648 is invalid format.")
+      expect { subject.parse_key_path("m/2147483648'") }.to raise_error(
+        ArgumentError,
+        "m/2147483648' is invalid format."
+      )
+      expect { subject.parse_key_path("m/4294967296") }.to raise_error(ArgumentError, "m/4294967296 is invalid format.")
+    end
+  end
+
+  describe "#to_key_path" do
+    it "should build a path" do
+      expect(subject.to_key_path([])).to eq("m/")
+      expect(subject.to_key_path([0])).to eq("m/0")
+      expect(subject.to_key_path([2_147_483_692, 2_147_486_025, 2_147_483_648, 0, 0])).to eq("m/44'/2377'/0'/0/0")
+    end
+
+    it "should be the inverse of #parse_key_path" do
+      %w[m/0 m/0' m/44'/2377'/0'/0/0 m/2147483647'].each do |path|
+        expect(subject.to_key_path(subject.parse_key_path(path))).to eq(path)
+      end
+    end
+  end
+end

--- a/spec/tapyrus/pstt_spec.rb
+++ b/spec/tapyrus/pstt_spec.rb
@@ -1137,6 +1137,32 @@ RSpec.describe Tapyrus::PSTT do
       expect(parsed.xpubs.keys).to eq([account.to_base58])
       expect(parsed.xpubs.values.first.path).to eq("m/44'/1'/0'")
     end
+
+    it "rejects a malformed derivation path" do
+      expect { Tapyrus::PSTT::KeyOriginInfo.from_path("f05655ac", "m/44'/2377'/0'/0/1abc") }.to raise_error(
+        ArgumentError
+      )
+      expect { Tapyrus::PSTT::KeyOriginInfo.from_path("f05655ac", "m/1'2") }.to raise_error(ArgumentError)
+    end
+
+    # Array#pack("V") truncates a value which does not fit in 4 bytes without raising, so a path
+    # element out of range would be carried through serialization as a different one.
+    it "rejects a derivation path element which is not a 32-bit unsigned integer" do
+      expect { Tapyrus::PSTT::KeyOriginInfo.new(fingerprint: "f05655ac", key_paths: [0x100000000]) }.to raise_error(
+        Tapyrus::PSTT::Error,
+        "Each derivation path element must be a 32-bit unsigned integer."
+      )
+      expect { Tapyrus::PSTT::KeyOriginInfo.new(fingerprint: "f05655ac", key_paths: [-1]) }.to raise_error(
+        Tapyrus::PSTT::Error,
+        "Each derivation path element must be a 32-bit unsigned integer."
+      )
+    end
+
+    it "accepts the largest derivation path element" do
+      origin = Tapyrus::PSTT::KeyOriginInfo.new(fingerprint: "f05655ac", key_paths: [0xffffffff])
+      expect(origin.path).to eq("m/2147483647'")
+      expect(Tapyrus::PSTT::KeyOriginInfo.parse_from_payload(origin.to_payload)).to eq(origin)
+    end
   end
 
   describe "Proprietary" do

--- a/spec/tapyrus/pstt_spec.rb
+++ b/spec/tapyrus/pstt_spec.rb
@@ -1,0 +1,1158 @@
+require "spec_helper"
+
+RSpec.describe Tapyrus::PSTT do
+  let(:keys) { 6.times.map { Tapyrus::Key.generate } }
+
+  # Build a transaction which pays +outputs+, so that it can be referenced as PSTT_IN_UTXO.
+  def funding_tx(*outputs)
+    tx = Tapyrus::Tx.new
+    tx.inputs << Tapyrus::TxIn.new(out_point: Tapyrus::OutPoint.from_txid(SecureRandom.hex(32), 0))
+    outputs.each { |value, script| tx.outputs << Tapyrus::TxOut.new(value: value, script_pubkey: script) }
+    tx
+  end
+
+  def p2pkh(key)
+    Tapyrus::Script.to_p2pkh(key.hash160)
+  end
+
+  def pstt_input(tx, index)
+    Tapyrus::PSTT::Input.new(out_point: Tapyrus::OutPoint.from_txid(tx.txid, index), utxo: tx)
+  end
+
+  def pstt_output(value, script)
+    Tapyrus::PSTT::Output.new(amount: value, script_pubkey: script)
+  end
+
+  # The records of every map of +payload+, sorted so that two PSTTs which differ only in the
+  # order of their records compare equal.
+  def records_of(payload)
+    buf = StringIO.new(payload)
+    Tapyrus::PSTT.read_bytes(buf, Tapyrus::PSTT::MAGIC.bytesize)
+    maps = []
+    maps << Tapyrus::PSTT.parse_map(buf).map { |r| [r.type, r.keydata.bth, r.value.bth] }.sort until buf.eof?
+    maps
+  end
+
+  describe "TIP-0174 test vectors" do
+    describe "invalid.json" do
+      fixture_file("tip0174/invalid.json").each do |vector|
+        context "with #{vector["id"]}" do
+          subject { Tapyrus::PSTT::Tx.from_base64(vector["pstt"]) }
+
+          if vector["expected"]["stage"] == "parse"
+            it "is rejected while parsing: #{vector["expected"]["reason"]}" do
+              expect { subject }.to raise_error(Tapyrus::PSTT::Error)
+            end
+          else
+            it "parses, but violates a role rule: #{vector["expected"]["reason"]}" do
+              expect { subject }.not_to raise_error
+            end
+          end
+        end
+      end
+
+      it "detects an unmatched PSTT_IN_UTXO" do
+        pstt = Tapyrus::PSTT::Tx.from_base64(invalid_vector("utxo-txid-mismatch"))
+        expect { pstt.sighash_for_input(0) }.to raise_error(
+          Tapyrus::PSTT::Error,
+          "The txid of PSTT_IN_UTXO does not match PSTT_IN_PREVIOUS_TXID."
+        )
+      end
+
+      it "detects contradictory required locktimes" do
+        pstt = Tapyrus::PSTT::Tx.from_base64(invalid_vector("contradictory-locktimes"))
+        expect { pstt.locktime }.to raise_error(
+          Tapyrus::PSTT::Error,
+          "No locktime kind is acceptable to every input which requires a locktime."
+        )
+      end
+
+      it "detects SIGHASH_SINGLE without a corresponding output" do
+        pstt = Tapyrus::PSTT::Tx.from_base64(invalid_vector("single-without-corresponding-output"))
+        index = pstt.inputs.index { |input| !input.partial_sigs.empty? }
+        expect(index).to be >= pstt.outputs.size
+        expect { pstt.sighash_for_input(index, sighash_type: Tapyrus::SIGHASH_TYPE[:single]) }.to raise_error(
+          Tapyrus::PSTT::Error,
+          "SIGHASH_SINGLE must not be used for an input which has no corresponding output."
+        )
+      end
+
+      it "detects a redeem script which does not hash to the committed value" do
+        pstt = Tapyrus::PSTT::Tx.from_base64(invalid_vector("redeem-script-hash-mismatch"))
+        expect { pstt.sighash_for_input(0) }.to raise_error(
+          Tapyrus::PSTT::Error,
+          "PSTT_IN_REDEEM_SCRIPT does not hash to the value committed in the scriptPubKey."
+        )
+      end
+
+      it "detects a map count which does not match the declared counts" do
+        expect { Tapyrus::PSTT::Tx.from_base64(invalid_vector("count-mismatch")) }.to raise_error(
+          Tapyrus::PSTT::Error,
+          "The number of maps does not match PSTT_GLOBAL_INPUT_COUNT and PSTT_GLOBAL_OUTPUT_COUNT."
+        )
+      end
+
+      it "detects a keytype which is not minimally encoded" do
+        expect { Tapyrus::PSTT::Tx.from_base64(invalid_vector("non-minimal-keytype")) }.to raise_error(
+          Tapyrus::PSTT::Error,
+          "compact size is not minimally encoded."
+        )
+      end
+
+      def invalid_vector(id)
+        fixture_file("tip0174/invalid.json").find { |v| v["id"] == id }["pstt"]
+      end
+    end
+
+    describe "valid.json" do
+      fixture_file("tip0174/valid.json").each do |series|
+        context "with #{series["id"]}" do
+          let(:stages) { series["stages"].map { |stage| Tapyrus::PSTT::Tx.from_base64(stage["pstt"]) } }
+
+          it "parses every stage and survives a round trip" do
+            series["stages"].each_with_index do |stage, i|
+              pstt = stages[i]
+              # The records themselves are compared first: a field this implementation silently
+              # dropped shows up here, with a readable difference.
+              expect(records_of(pstt.to_payload)).to eq(records_of(stage["pstt"].unpack1("m0")))
+              # The round trip is then byte-exact, because every map is re-emitted in the order
+              # it was read. TIP-0174 prescribes no order, but reproducing the bytes lets a
+              # caller hash, cache or diff a PSTT without normalizing it first.
+              expect(pstt.to_payload).to eq(stage["pstt"].unpack1("m0"))
+              expect(Tapyrus::PSTT::Tx.parse_from_payload(pstt.to_payload)).to eq(pstt)
+              expect(Tapyrus::PSTT::Tx.from_base64(pstt.to_base64)).to eq(pstt)
+              expect(pstt.identification_txid).to eq(stage["identification_txid"]) if stage["identification_txid"]
+              # A stage which declares 0 asserts that every modifiable flag has been cleared.
+              expect(pstt.tx_modifiable).to eq(stage["tx_modifiable"]) unless stage["tx_modifiable"].nil?
+            end
+          end
+
+          it "extracts the final transaction" do
+            tx = stages.last.extract_tx
+            expect(tx.to_hex).to eq(series["extracted_tx"])
+            expect(tx.txid).to eq(series["final_txid"])
+          end
+
+          it "computes the scriptCode, the signature hash and verifies the signatures" do
+            signed = stages.select { |pstt| pstt.inputs.any? { |input| !input.partial_sigs.empty? } }.last
+            expect(signed).not_to be_nil
+            series["intermediates"].each do |intermediate|
+              index = intermediate["input"]
+              expect(signed.script_code(index).to_hex).to eq(intermediate["script_code"])
+              sighash = signed.sighash_for_input(index, sighash_type: intermediate["sighash_type"])
+              expect(sighash.bth).to eq(intermediate["sighash"])
+              sig = signed.inputs[index].partial_sigs[intermediate["pubkey"]]
+              expect(sig.bth).to eq(intermediate["signature"])
+              expect(sig[-1].unpack1("C")).to eq(intermediate["sighash_type"])
+              algo = sig.bytesize == 65 ? :schnorr : :ecdsa
+              key = Tapyrus::Key.new(pubkey: intermediate["pubkey"])
+              expect(key.verify(sig[0...-1], sighash, algo: algo)).to be true
+            end
+          end
+        end
+      end
+    end
+  end
+
+  describe "container format" do
+    # A PSTT which carries one P2PKH input and one output, for the payloads assembled by hand.
+    def one_input_pstt
+      Tapyrus::PSTT::Tx.new(
+        inputs: [pstt_input(funding_tx([100_000, p2pkh(keys[0])]), 0)],
+        outputs: [pstt_output(99_000, p2pkh(keys[1]))]
+      )
+    end
+
+    # Replace the first occurrence of +from+ in +payload+ with +to+.
+    def mangle(payload, from, to)
+      index = payload.index(from)
+      expect(index).not_to be_nil
+      payload[0...index] + to + payload[(index + from.bytesize)..]
+    end
+
+    def parse_error_of(payload)
+      Tapyrus::PSTT::Tx.parse_from_payload(payload)
+      nil
+    rescue Tapyrus::PSTT::Error => e
+      e.message
+    end
+
+    it "begins with the pstt magic" do
+      pstt = Tapyrus::PSTT::Tx.new
+      expect(pstt.to_payload[0...5].bth).to eq("70737474ff")
+    end
+
+    it "rejects a payload which does not begin with the magic" do
+      payload = Tapyrus::PSTT::Tx.new.to_payload
+      payload[0...5] = "70736274ff".htb # the Bitcoin PSBT magic
+      expect { Tapyrus::PSTT::Tx.parse_from_payload(payload) }.to raise_error(
+        Tapyrus::PSTT::Error,
+        /Invalid PSTT magic/
+      )
+    end
+
+    it "rejects a compact size which is not minimally encoded" do
+      # PSTT_GLOBAL_TX_FEATURES is <keylen=01> <keytype=02> <valuelen=04> <features>.
+      payload = one_input_pstt.to_payload
+      not_minimal = "compact size is not minimally encoded."
+      expect(parse_error_of(mangle(payload, "\x01\x02\x04".b, "\xfd\x01\x00\x02\x04".b))).to eq(not_minimal)
+      expect(parse_error_of(mangle(payload, "\x01\x02\x04".b, "\x01\x02\xfd\x04\x00".b))).to eq(not_minimal)
+    end
+
+    it "rejects a map separator which is not a single 0x00 byte" do
+      # 0xfd 0x00 0x00 encodes the same 0, so a parser which only compared the value would read
+      # it as the separator and accept two byte strings as the same PSTT.
+      records = Tapyrus::PSTT::Tx.new.global_records
+      payload = Tapyrus::PSTT::MAGIC + records.map(&:to_payload).join + "\xfd\x00\x00".b
+      expect(parse_error_of(payload)).to eq("compact size is not minimally encoded.")
+    end
+
+    it "rejects a count which is not minimally encoded" do
+      pstt = one_input_pstt
+      records = pstt.global_records
+      records.find { |r| r.type == Tapyrus::PSTT::GlobalTypes::INPUT_COUNT }.value = "\xfd\x01\x00".b
+      payload =
+        Tapyrus::PSTT::MAGIC + Tapyrus::PSTT.serialize_map(records) + pstt.inputs.map(&:to_payload).join +
+          pstt.outputs.map(&:to_payload).join
+      expect(parse_error_of(payload)).to eq("compact size is not minimally encoded.")
+    end
+
+    it "rejects a PSTT whose number of maps does not match the declared counts" do
+      pstt = one_input_pstt
+      records = pstt.global_records
+      records.find { |r| r.type == Tapyrus::PSTT::GlobalTypes::INPUT_COUNT }.value = Tapyrus.pack_var_int(2)
+      payload =
+        Tapyrus::PSTT::MAGIC + Tapyrus::PSTT.serialize_map(records) + pstt.inputs.map(&:to_payload).join +
+          pstt.outputs.map(&:to_payload).join
+      expect(parse_error_of(payload)).to eq(
+        "The number of maps does not match PSTT_GLOBAL_INPUT_COUNT and PSTT_GLOBAL_OUTPUT_COUNT."
+      )
+    end
+
+    it "re-emits the records of a map in the order they were read" do
+      pstt = one_input_pstt
+      # An order this implementation would never generate on its own.
+      order = pstt.global_records.reverse.map(&:key)
+      payload =
+        Tapyrus::PSTT::MAGIC + Tapyrus::PSTT.serialize_map(pstt.global_records, order) +
+          pstt.inputs.map(&:to_payload).join + pstt.outputs.map(&:to_payload).join
+      parsed = Tapyrus::PSTT::Tx.parse_from_payload(payload)
+      expect(parsed.global_record_order).to eq(order)
+      expect(parsed.to_payload).to eq(payload)
+    end
+
+    it "puts a record collected after parsing behind the records which were read" do
+      parsed = Tapyrus::PSTT::Tx.parse_from_payload(one_input_pstt.to_payload)
+      before = input_keys_of(parsed.to_payload)
+      parsed.sign(0, keys[0])
+      after = input_keys_of(parsed.to_payload)
+      expect(after.first(before.size)).to eq(before)
+      expect(after.last).to eq(Tapyrus.pack_var_int(Tapyrus::PSTT::InputTypes::PARTIAL_SIG) + keys[0].pubkey.htb)
+    end
+
+    # The complete keys of the first input map of +payload+, in the order they are emitted.
+    def input_keys_of(payload)
+      buf = StringIO.new(payload)
+      Tapyrus::PSTT.read_bytes(buf, Tapyrus::PSTT::MAGIC.bytesize)
+      Tapyrus::PSTT.parse_map(buf)
+      Tapyrus::PSTT.parse_map(buf).map(&:key)
+    end
+
+    it "keeps unknown records through a round trip" do
+      pstt = Tapyrus::PSTT::Tx.new
+      pstt.unknowns[Tapyrus.pack_var_int(0x20)] = "future-field"
+      pstt.inputs << pstt_input(funding_tx([1_000, p2pkh(keys[0])]), 0)
+      pstt.inputs.first.unknowns[Tapyrus.pack_var_int(0x21) + "01".htb] = "future-input-field"
+      pstt.outputs << pstt_output(900, p2pkh(keys[1]))
+      pstt.outputs.first.unknowns[Tapyrus.pack_var_int(0x22)] = "future-output-field"
+      parsed = Tapyrus::PSTT::Tx.parse_from_payload(pstt.to_payload)
+      expect(parsed.unknowns[Tapyrus.pack_var_int(0x20)]).to eq("future-field")
+      expect(parsed.inputs.first.unknowns.values).to eq(["future-input-field"])
+      expect(parsed.outputs.first.unknowns.values).to eq(["future-output-field"])
+    end
+
+    it "rejects a version greater than 0, both when writing and when reading" do
+      expect { Tapyrus::PSTT::Tx.new(version: 1).to_payload }.to raise_error(
+        Tapyrus::PSTT::Error,
+        "PSTT version 1 is not supported."
+      )
+      pstt = Tapyrus::PSTT::Tx.new
+      records = pstt.global_records << Tapyrus::PSTT::KeyValue.new(0xfb, "".b, [1].pack("V"))
+      payload = Tapyrus::PSTT::MAGIC + Tapyrus::PSTT.serialize_map(records)
+      expect { Tapyrus::PSTT::Tx.parse_from_payload(payload) }.to raise_error(
+        Tapyrus::PSTT::Error,
+        "PSTT version 1 is not supported."
+      )
+    end
+
+    it "rejects a reserved bit of PSTT_GLOBAL_TX_MODIFIABLE, both when writing and when reading" do
+      expect { Tapyrus::PSTT::Tx.new(tx_modifiable: 0x08).to_payload }.to raise_error(
+        Tapyrus::PSTT::Error,
+        "The reserved bits of PSTT_GLOBAL_TX_MODIFIABLE must be 0."
+      )
+    end
+
+    it "reports a malformed PSTT_IN_UTXO as a PSTT error" do
+      pstt =
+        Tapyrus::PSTT::Tx.new(
+          inputs: [pstt_input(funding_tx([1_000, p2pkh(keys[0])]), 0)],
+          outputs: [pstt_output(900, p2pkh(keys[1]))]
+        )
+      records = pstt.inputs.first.to_records
+      records.find { |r| r.type == Tapyrus::PSTT::InputTypes::UTXO }.value = "deadbeef".htb
+      payload =
+        Tapyrus::PSTT::MAGIC + Tapyrus::PSTT.serialize_map(pstt.global_records) + Tapyrus::PSTT.serialize_map(records) +
+          pstt.outputs.map(&:to_payload).join
+      expect { Tapyrus::PSTT::Tx.parse_from_payload(payload) }.to raise_error(
+        Tapyrus::PSTT::Error,
+        /PSTT_IN_UTXO is malformed/
+      )
+    end
+
+    it "reports a malformed PSTT_GLOBAL_XPUB as a PSTT error" do
+      records = Tapyrus::PSTT::Tx.new.global_records
+      records << Tapyrus::PSTT::KeyValue.new(0x01, "ff".htb * 78, "00".htb * 4)
+      payload = Tapyrus::PSTT::MAGIC + Tapyrus::PSTT.serialize_map(records)
+      expect { Tapyrus::PSTT::Tx.parse_from_payload(payload) }.to raise_error(
+        Tapyrus::PSTT::Error,
+        /PSTT_GLOBAL_XPUB is malformed/
+      )
+    end
+
+    it "rejects an empty PSTT_IN_PARTIAL_SIG" do
+      pstt =
+        Tapyrus::PSTT::Tx.new(
+          inputs: [pstt_input(funding_tx([1_000, p2pkh(keys[0])]), 0)],
+          outputs: [pstt_output(900, p2pkh(keys[1]))]
+        )
+      pstt.inputs.first.partial_sigs[keys[0].pubkey] = "".b
+      expect { Tapyrus::PSTT::Tx.parse_from_payload(pstt.to_payload) }.to raise_error(
+        Tapyrus::PSTT::Error,
+        /PSTT_IN_PARTIAL_SIG must carry a signature/
+      )
+    end
+
+    it "does not let an empty PSTT_IN_PARTIAL_SIG break the sequence number rule" do
+      pstt =
+        Tapyrus::PSTT::Tx.new(
+          inputs: [
+            pstt_input(funding_tx([1_000, p2pkh(keys[0])]), 0),
+            pstt_input(funding_tx([1_000, p2pkh(keys[1])]), 0)
+          ],
+          outputs: [pstt_output(1_900, p2pkh(keys[2]))]
+        )
+      pstt.inputs.last.partial_sigs[keys[1].pubkey] = "".b
+      expect { pstt.set_sequence(0, 0xfffffffe) }.not_to raise_error
+    end
+
+    it "rejects an out-of-range PSTT_OUT_AMOUNT, both when writing and when reading" do
+      pstt =
+        Tapyrus::PSTT::Tx.new(
+          inputs: [pstt_input(funding_tx([1_000, p2pkh(keys[0])]), 0)],
+          outputs: [pstt_output(-1, p2pkh(keys[1]))]
+        )
+      expect { pstt.to_payload }.to raise_error(Tapyrus::PSTT::Error, /PSTT_OUT_AMOUNT must be between/)
+
+      pstt.outputs.first.amount = 1
+      records = pstt.outputs.first.to_records
+      records.find { |r| r.type == Tapyrus::PSTT::OutputTypes::AMOUNT }.value = [-1].pack("q<")
+      payload =
+        Tapyrus::PSTT::MAGIC + Tapyrus::PSTT.serialize_map(pstt.global_records) + pstt.inputs.map(&:to_payload).join +
+          Tapyrus::PSTT.serialize_map(records)
+      expect { Tapyrus::PSTT::Tx.parse_from_payload(payload) }.to raise_error(
+        Tapyrus::PSTT::Error,
+        /PSTT_OUT_AMOUNT must be between/
+      )
+    end
+  end
+
+  describe "P2PKH workflow" do
+    let(:prev_tx) { funding_tx([100_000, p2pkh(keys[0])]) }
+
+    it "walks from creation to extraction with an ECDSA signature" do
+      pstt =
+        Tapyrus::PSTT::Tx.new(
+          inputs: [pstt_input(prev_tx, 0)],
+          outputs: [pstt_output(70_000, p2pkh(keys[1])), pstt_output(29_000, p2pkh(keys[2]))]
+        )
+      expect(pstt.fee).to eq(1_000)
+      expect(pstt.script_code(0)).to eq(p2pkh(keys[0]))
+
+      pstt.sign(0, keys[0])
+      expect(pstt.inputs.first.partial_sigs.size).to eq(1)
+
+      pstt.finalize!
+      tx = pstt.extract_tx
+      # The identifier is computed with every sequence number set to 0, so it differs from the final txid.
+      expect(tx.txid).not_to eq(pstt.identification_txid)
+      expect(tx.verify_input_sig(0, prev_tx.outputs.first.script_pubkey)).to be true
+    end
+
+    it "signs with the Tapyrus Schnorr scheme" do
+      pstt = Tapyrus::PSTT::Tx.new(inputs: [pstt_input(prev_tx, 0)], outputs: [pstt_output(99_000, p2pkh(keys[1]))])
+      sig = pstt.sign(0, keys[0], algo: :schnorr)
+      expect(sig.bytesize).to eq(65)
+      expect(keys[0].verify(sig[0...-1], pstt.sighash_for_input(0), algo: :schnorr)).to be true
+      pstt.finalize!
+      expect(pstt.extract_tx.verify_input_sig(0, prev_tx.outputs.first.script_pubkey)).to be true
+    end
+
+    it "does not sign an input which has no PSTT_IN_UTXO" do
+      pstt = Tapyrus::PSTT::Tx.new(inputs: [pstt_input(prev_tx, 0)], outputs: [pstt_output(99_000, p2pkh(keys[1]))])
+      pstt.inputs.first.utxo = nil
+      expect { pstt.sign(0, keys[0]) }.to raise_error(Tapyrus::PSTT::Error, "PSTT_IN_UTXO is required.")
+    end
+
+    it "does not sign an input whose PSTT_IN_UTXO does not match the outpoint" do
+      pstt = Tapyrus::PSTT::Tx.new(inputs: [pstt_input(prev_tx, 0)], outputs: [pstt_output(99_000, p2pkh(keys[1]))])
+      pstt.inputs.first.utxo = funding_tx([100_000, p2pkh(keys[0])])
+      expect { pstt.sign(0, keys[0]) }.to raise_error(
+        Tapyrus::PSTT::Error,
+        "The txid of PSTT_IN_UTXO does not match PSTT_IN_PREVIOUS_TXID."
+      )
+    end
+
+    it "uses the sighash type PSTT_IN_SIGHASH_TYPE requires" do
+      pstt = Tapyrus::PSTT::Tx.new(inputs: [pstt_input(prev_tx, 0)], outputs: [pstt_output(99_000, p2pkh(keys[1]))])
+      pstt.inputs.first.sighash_type = Tapyrus::SIGHASH_TYPE[:none]
+      sig = pstt.sign(0, keys[0])
+      expect(sig[-1].unpack1("C")).to eq(Tapyrus::SIGHASH_TYPE[:none])
+      expect { pstt.sign(0, keys[0], sighash_type: Tapyrus::SIGHASH_TYPE[:all]) }.to raise_error(
+        Tapyrus::PSTT::Error,
+        /sighash type of this input is fixed/
+      )
+    end
+
+    it "does not sign with a sighash type TIP-0174 does not define" do
+      pstt = Tapyrus::PSTT::Tx.new(inputs: [pstt_input(prev_tx, 0)], outputs: [pstt_output(99_000, p2pkh(keys[1]))])
+      # Only the low byte reaches the signature, while the whole value is committed to by the
+      # signature hash, so a value which does not fit in a byte would yield an unverifiable signature.
+      expect { pstt.sign(0, keys[0], sighash_type: 0x0101) }.to raise_error(
+        Tapyrus::PSTT::Error,
+        "Sighash type 0x101 is not defined by TIP-0174."
+      )
+      expect { pstt.sign(0, keys[0], sighash_type: 0x04) }.to raise_error(
+        Tapyrus::PSTT::Error,
+        /is not defined by TIP-0174/
+      )
+      # The same holds when the sighash type comes from PSTT_IN_SIGHASH_TYPE instead of the caller.
+      pstt.inputs.first.sighash_type = 0x0101
+      expect { pstt.sign(0, keys[0]) }.to raise_error(Tapyrus::PSTT::Error, /is not defined by TIP-0174/)
+    end
+
+    it "rejects a PSTT_IN_SIGHASH_TYPE which TIP-0174 does not define, both when writing and when reading" do
+      pstt = Tapyrus::PSTT::Tx.new(inputs: [pstt_input(prev_tx, 0)], outputs: [pstt_output(99_000, p2pkh(keys[1]))])
+      records =
+        pstt.inputs.first.to_records << Tapyrus::PSTT::KeyValue.new(
+          Tapyrus::PSTT::InputTypes::SIGHASH_TYPE,
+          "".b,
+          [0x04].pack("V")
+        )
+      payload =
+        Tapyrus::PSTT::MAGIC + Tapyrus::PSTT.serialize_map(pstt.global_records) + Tapyrus::PSTT.serialize_map(records) +
+          pstt.outputs.map(&:to_payload).join
+      expect { Tapyrus::PSTT::Tx.parse_from_payload(payload) }.to raise_error(
+        Tapyrus::PSTT::Error,
+        "Sighash type 0x4 is not defined by TIP-0174."
+      )
+
+      pstt.inputs.first.sighash_type = 0x04
+      expect { pstt.to_payload }.to raise_error(Tapyrus::PSTT::Error, /is not defined by TIP-0174/)
+    end
+
+    it "rejects a signature whose sighash type contradicts PSTT_IN_SIGHASH_TYPE" do
+      pstt = Tapyrus::PSTT::Tx.new(inputs: [pstt_input(prev_tx, 0)], outputs: [pstt_output(99_000, p2pkh(keys[1]))])
+      pstt.sign(0, keys[0], sighash_type: Tapyrus::SIGHASH_TYPE[:all])
+      records =
+        pstt.inputs.first.to_records << Tapyrus::PSTT::KeyValue.new(
+          Tapyrus::PSTT::InputTypes::SIGHASH_TYPE,
+          "".b,
+          [Tapyrus::SIGHASH_TYPE[:none]].pack("V")
+        )
+      payload =
+        Tapyrus::PSTT::MAGIC + Tapyrus::PSTT.serialize_map(pstt.global_records) + Tapyrus::PSTT.serialize_map(records) +
+          pstt.outputs.map(&:to_payload).join
+      expect { Tapyrus::PSTT::Tx.parse_from_payload(payload) }.to raise_error(
+        Tapyrus::PSTT::Error,
+        /uses sighash type 0x1, but PSTT_IN_SIGHASH_TYPE requires 0x2/
+      )
+
+      pstt.inputs.first.sighash_type = Tapyrus::SIGHASH_TYPE[:none]
+      expect { pstt.to_payload }.to raise_error(Tapyrus::PSTT::Error, /uses sighash type 0x1/)
+      expect { pstt.sighash_for_input(0, sighash_type: Tapyrus::SIGHASH_TYPE[:none]) }.to raise_error(
+        Tapyrus::PSTT::Error,
+        /uses sighash type 0x1/
+      )
+    end
+
+    it "signs with every sighash type TIP-0174 defines" do
+      Tapyrus::PSTT::SIGHASH_TYPES.each do |hash_type|
+        pstt = Tapyrus::PSTT::Tx.new(inputs: [pstt_input(prev_tx, 0)], outputs: [pstt_output(99_000, p2pkh(keys[1]))])
+        sig = pstt.sign(0, keys[0], sighash_type: hash_type)
+        expect(sig[-1].unpack1("C")).to eq(hash_type)
+        sighash = pstt.sighash_for_input(0, sighash_type: hash_type)
+        expect(keys[0].verify(sig[0...-1], sighash)).to be true
+      end
+    end
+  end
+
+  describe "Colored Coin workflow" do
+    let(:color_id) { Tapyrus::Color::ColorIdentifier.reissuable(p2pkh(keys[0])) }
+    let(:cp2pkh) { Tapyrus::Script.to_cp2pkh(color_id, keys[0].hash160) }
+    let(:token_tx) { funding_tx([100, cp2pkh]) }
+    let(:fee_tx) { funding_tx([10_000, p2pkh(keys[3])]) }
+
+    it "transfers tokens with a TPC input which pays the fee" do
+      pstt =
+        Tapyrus::PSTT::Tx.new(
+          inputs: [pstt_input(token_tx, 0), pstt_input(fee_tx, 0)],
+          outputs: [
+            pstt_output(100, Tapyrus::Script.to_cp2pkh(color_id, keys[1].hash160)),
+            pstt_output(9_000, p2pkh(keys[3]))
+          ]
+        )
+      expect(pstt.input_amounts[color_id]).to eq(100)
+      expect(pstt.output_amounts[color_id]).to eq(100)
+      expect(pstt.fee).to eq(1_000)
+
+      # The scriptCode of a CP2PKH input is the full scriptPubKey, including the color prefix.
+      expect(pstt.script_code(0)).to eq(cp2pkh)
+      expect(pstt.script_code(0).colored?).to be true
+
+      pstt.sign(0, keys[0])
+      pstt.sign(1, keys[3])
+      pstt.finalize!
+      tx = pstt.extract_tx
+      expect(tx.verify_input_sig(0, cp2pkh)).to be true
+      expect(tx.verify_input_sig(1, p2pkh(keys[3]))).to be true
+    end
+
+    it "signs a 2-of-2 CP2SH multisig input in parallel and combines the results" do
+      redeem_script = Tapyrus::Script.to_multisig_script(2, [keys[0].pubkey, keys[1].pubkey])
+      cp2sh = Tapyrus::Script.to_cp2sh(color_id, redeem_script.to_hash160)
+      prev_tx = funding_tx([50, cp2sh])
+
+      base =
+        Tapyrus::PSTT::Tx.new(
+          inputs: [pstt_input(prev_tx, 0)],
+          outputs: [pstt_output(50, Tapyrus::Script.to_cp2pkh(color_id, keys[2].hash160))]
+        )
+      base.inputs.first.redeem_script = redeem_script
+      # The scriptCode of a CP2SH input is the redeem script, without the color identifier prefix.
+      expect(base.script_code(0)).to eq(redeem_script)
+      expect(base.script_code(0).colored?).to be false
+
+      alice = Tapyrus::PSTT::Tx.parse_from_payload(base.to_payload)
+      bob = Tapyrus::PSTT::Tx.parse_from_payload(base.to_payload)
+      alice.sign(0, keys[0])
+      bob.sign(0, keys[1])
+
+      combined = alice.combine(bob)
+      expect(combined.inputs.first.partial_sigs.keys).to contain_exactly(keys[0].pubkey, keys[1].pubkey)
+
+      sighash = combined.sighash_for_input(0)
+      combined.inputs.first.partial_sigs.each do |pubkey, sig|
+        expect(Tapyrus::Key.new(pubkey: pubkey).verify(sig[0...-1], sighash)).to be true
+      end
+
+      combined.finalize!
+      expect(combined.inputs.first.partial_sigs).to be_empty
+      expect(combined.inputs.first.redeem_script).to be_nil
+      # OP_0 <sig> <sig> <redeem script>
+      script_sig = combined.extract_tx.inputs.first.script_sig
+      expect(script_sig.chunks.size).to eq(4)
+      expect(script_sig.chunks.first.opcode).to eq(Tapyrus::Opcodes::OP_0)
+      expect(script_sig.chunks.last.pushed_data).to eq(redeem_script.to_payload)
+    end
+
+    it "finalizes a 2-of-2 P2SH multisig input into a spendable scriptSig" do
+      redeem_script = Tapyrus::Script.to_multisig_script(2, [keys[0].pubkey, keys[1].pubkey])
+      p2sh = Tapyrus::Script.to_p2sh(redeem_script.to_hash160)
+      prev_tx = funding_tx([100_000, p2sh])
+      pstt = Tapyrus::PSTT::Tx.new(inputs: [pstt_input(prev_tx, 0)], outputs: [pstt_output(99_000, p2pkh(keys[2]))])
+      pstt.inputs.first.redeem_script = redeem_script
+      expect(pstt.script_code(0)).to eq(redeem_script)
+      pstt.sign(0, keys[0])
+      pstt.sign(0, keys[1])
+      pstt.finalize!
+      expect(pstt.extract_tx.verify_input_sig(0, p2sh)).to be true
+    end
+
+    it "does not sign when the redeem script does not hash to the committed value" do
+      redeem_script = Tapyrus::Script.to_multisig_script(2, [keys[0].pubkey, keys[1].pubkey])
+      prev_tx = funding_tx([100_000, Tapyrus::Script.to_p2sh(redeem_script.to_hash160)])
+      pstt = Tapyrus::PSTT::Tx.new(inputs: [pstt_input(prev_tx, 0)], outputs: [pstt_output(99_000, p2pkh(keys[2]))])
+      pstt.inputs.first.redeem_script = Tapyrus::Script.to_multisig_script(2, [keys[0].pubkey, keys[2].pubkey])
+      expect { pstt.sign(0, keys[0]) }.to raise_error(
+        Tapyrus::PSTT::Error,
+        "PSTT_IN_REDEEM_SCRIPT does not hash to the value committed in the scriptPubKey."
+      )
+    end
+
+    it "does not mix ECDSA and Schnorr signatures within one input" do
+      redeem_script = Tapyrus::Script.to_multisig_script(2, [keys[0].pubkey, keys[1].pubkey])
+      prev_tx = funding_tx([50, Tapyrus::Script.to_p2sh(redeem_script.to_hash160)])
+      pstt = Tapyrus::PSTT::Tx.new(inputs: [pstt_input(prev_tx, 0)], outputs: [pstt_output(40, p2pkh(keys[2]))])
+      pstt.inputs.first.redeem_script = redeem_script
+      pstt.sign(0, keys[0], algo: :ecdsa)
+      expect { pstt.sign(0, keys[1], algo: :schnorr) }.to raise_error(Tapyrus::PSTT::Error, /must not be mixed/)
+    end
+  end
+
+  describe "construction" do
+    let(:prev_tx) { funding_tx([100_000, p2pkh(keys[0])]) }
+
+    it "adds inputs and outputs while the modifiable flags are set" do
+      pstt = Tapyrus::PSTT::Tx.new(tx_modifiable: Tapyrus::PSTT::TxModifiable::ALL & ~4)
+      expect(pstt.inputs_modifiable?).to be true
+      expect(pstt.outputs_modifiable?).to be true
+
+      empty_id = pstt.identification_txid
+      pstt.add_input(pstt_input(prev_tx, 0))
+      expect(pstt.identification_txid).not_to eq(empty_id)
+      pstt.add_output(pstt_output(99_000, p2pkh(keys[1])))
+
+      parsed = Tapyrus::PSTT::Tx.parse_from_payload(pstt.to_payload)
+      expect(parsed.inputs.size).to eq(1)
+      expect(parsed.outputs.size).to eq(1)
+
+      pstt.finish_construction!
+      expect(pstt.inputs_modifiable?).to be false
+      expect(pstt.outputs_modifiable?).to be false
+      expect { pstt.add_output(pstt_output(1, p2pkh(keys[2]))) }.to raise_error(
+        Tapyrus::PSTT::Error,
+        "Outputs are not modifiable."
+      )
+    end
+
+    it "does not add an input when the Inputs Modifiable flag is clear" do
+      pstt = Tapyrus::PSTT::Tx.new
+      expect { pstt.add_input(pstt_input(prev_tx, 0)) }.to raise_error(
+        Tapyrus::PSTT::Error,
+        "Inputs are not modifiable."
+      )
+    end
+
+    it "does not finalize while the PSTT is still modifiable" do
+      pstt =
+        Tapyrus::PSTT::Tx.new(
+          tx_modifiable: Tapyrus::PSTT::TxModifiable::INPUTS,
+          inputs: [pstt_input(prev_tx, 0)],
+          outputs: [pstt_output(99_000, p2pkh(keys[1]))]
+        )
+      expect { pstt.finalize! }.to raise_error(
+        Tapyrus::PSTT::Error,
+        "A PSTT must not be finalized while it is still modifiable."
+      )
+    end
+
+    it "does not add an input which changes the locktime of a PSTT that already holds signatures" do
+      pstt =
+        Tapyrus::PSTT::Tx.new(
+          tx_modifiable: Tapyrus::PSTT::TxModifiable::INPUTS,
+          inputs: [pstt_input(prev_tx, 0)],
+          outputs: [pstt_output(99_000, p2pkh(keys[1]))]
+        )
+      pstt.sign(0, keys[0], sighash_type: Tapyrus::SIGHASH_TYPE[:all] | Tapyrus::SIGHASH_TYPE[:anyonecanpay])
+      added = pstt_input(funding_tx([5_000, p2pkh(keys[2])]), 0)
+      added.required_height_locktime = 100
+      expect { pstt.add_input(added) }.to raise_error(
+        Tapyrus::PSTT::Error,
+        "The added input changes the locktime of a PSTT which already contains signatures."
+      )
+      expect(pstt.inputs.size).to eq(1)
+    end
+
+    it "keeps inputs and outputs paired once a SIGHASH_SINGLE signature is present" do
+      pstt =
+        Tapyrus::PSTT::Tx.new(
+          tx_modifiable: Tapyrus::PSTT::TxModifiable::INPUTS | Tapyrus::PSTT::TxModifiable::OUTPUTS,
+          inputs: [pstt_input(prev_tx, 0)],
+          outputs: [pstt_output(99_000, p2pkh(keys[1]))]
+        )
+      pstt.sign(0, keys[0], sighash_type: Tapyrus::SIGHASH_TYPE[:single] | Tapyrus::SIGHASH_TYPE[:anyonecanpay])
+      expect(pstt.has_sighash_single?).to be true
+      expect(pstt.inputs_modifiable?).to be true
+      expect(pstt.outputs_modifiable?).to be false
+
+      other_tx = funding_tx([5_000, p2pkh(keys[2])])
+      expect { pstt.add_input(pstt_input(other_tx, 0)) }.to raise_error(Tapyrus::PSTT::Error, /add_pair/)
+      # Signing cleared the Outputs Modifiable flag, and that must not be undone to make room
+      # for the pair: the flags record what the collected signatures still allow.
+      expect { pstt.tx_modifiable |= Tapyrus::PSTT::TxModifiable::OUTPUTS }.to raise_error(
+        Tapyrus::PSTT::Error,
+        /must not be relaxed/
+      )
+    end
+
+    it "adds an input and an output as a pair while the Has SIGHASH_SINGLE flag is set" do
+      # Both modifiable flags are still set, so no signature of this PSTT is at stake and the
+      # Constructor may still extend it - in pairs, because the flag demands it.
+      pstt =
+        Tapyrus::PSTT::Tx.new(
+          tx_modifiable: Tapyrus::PSTT::TxModifiable::ALL,
+          inputs: [pstt_input(prev_tx, 0)],
+          outputs: [pstt_output(99_000, p2pkh(keys[1]))]
+        )
+      other_tx = funding_tx([5_000, p2pkh(keys[2])])
+      expect { pstt.add_input(pstt_input(other_tx, 0)) }.to raise_error(Tapyrus::PSTT::Error, /add_pair/)
+
+      pstt.add_pair(pstt_input(other_tx, 0), pstt_output(4_000, p2pkh(keys[3])))
+      expect(pstt.inputs.size).to eq(2)
+      expect(pstt.outputs.size).to eq(2)
+    end
+
+    it "adds a pair while the PSTT has more outputs than inputs" do
+      # Input 1 gets output 1, which is already there; the added output extends the tail. Every
+      # input still has an output at its own position, which is all SIGHASH_SINGLE asks for.
+      pstt =
+        Tapyrus::PSTT::Tx.new(
+          tx_modifiable: Tapyrus::PSTT::TxModifiable::ALL,
+          inputs: [pstt_input(prev_tx, 0)],
+          outputs: [pstt_output(50_000, p2pkh(keys[1])), pstt_output(49_000, p2pkh(keys[2]))]
+        )
+      pstt.add_pair(pstt_input(funding_tx([5_000, p2pkh(keys[3])]), 0), pstt_output(4_000, p2pkh(keys[4])))
+      expect(pstt.inputs.size).to eq(2)
+      expect(pstt.outputs.size).to eq(3)
+    end
+
+    it "does not add a pair which would leave an input without a corresponding output" do
+      pstt =
+        Tapyrus::PSTT::Tx.new(
+          tx_modifiable: Tapyrus::PSTT::TxModifiable::ALL,
+          inputs: [pstt_input(prev_tx, 0), pstt_input(funding_tx([5_000, p2pkh(keys[1])]), 0)],
+          outputs: [pstt_output(99_000, p2pkh(keys[2]))]
+        )
+      expect { pstt.add_pair(pstt_input(funding_tx([1, p2pkh(keys[3])]), 0), pstt_output(1, p2pkh(keys[4]))) }.to(
+        raise_error(Tapyrus::PSTT::Error, "The added input would have no corresponding output at a matching position.")
+      )
+      expect(pstt.inputs.size).to eq(2)
+      expect(pstt.outputs.size).to eq(1)
+    end
+
+    it "does not finalize or extract a PSTT which has no inputs" do
+      pstt = Tapyrus::PSTT::Tx.new(outputs: [pstt_output(1_000, p2pkh(keys[0]))])
+      expect { pstt.finalize! }.to raise_error(Tapyrus::PSTT::Error, "This PSTT has no inputs to finalize.")
+      expect { pstt.extract_tx }.to raise_error(Tapyrus::PSTT::Error, /This PSTT has no inputs/)
+    end
+  end
+
+  describe "the fields a signature commits to" do
+    let(:prev_tx) { funding_tx([100_000, p2pkh(keys[0])]) }
+
+    def signed_pstt(tx_modifiable: nil, input: pstt_input(prev_tx, 0), sighash_type: nil)
+      pstt =
+        Tapyrus::PSTT::Tx.new(
+          tx_modifiable: tx_modifiable,
+          inputs: [input],
+          outputs: [pstt_output(99_000, p2pkh(keys[1]))]
+        )
+      pstt.sign(0, keys[0], sighash_type: sighash_type)
+      pstt
+    end
+
+    it "does not change the features once a signature has been collected" do
+      pstt = signed_pstt
+      expect { pstt.features = 2 }.to raise_error(
+        Tapyrus::PSTT::Error,
+        "The features of a PSTT which already contains signatures must not be changed."
+      )
+      expect(pstt.features).to eq(1)
+    end
+
+    it "does not change PSTT_GLOBAL_FALLBACK_LOCKTIME once a signature has been collected" do
+      pstt = signed_pstt
+      sighash = pstt.sighash_for_input(0)
+      expect { pstt.fallback_locktime = 500 }.to raise_error(
+        Tapyrus::PSTT::Error,
+        /PSTT_GLOBAL_FALLBACK_LOCKTIME changes the locktime/
+      )
+      expect(pstt.fallback_locktime).to be_nil
+      expect(pstt.sighash_for_input(0)).to eq(sighash)
+    end
+
+    it "changes PSTT_GLOBAL_FALLBACK_LOCKTIME when no input consults it" do
+      # The guard is about the locktime the PSTT resolves to, not about the field itself.
+      input = pstt_input(prev_tx, 0).tap { |i| i.required_height_locktime = 100 }
+      pstt = signed_pstt(input: input)
+      expect(pstt.locktime).to eq(100)
+      pstt.fallback_locktime = 500
+      expect(pstt.locktime).to eq(100)
+    end
+
+    it "does not relax PSTT_GLOBAL_TX_MODIFIABLE once a signature has been collected" do
+      pstt = signed_pstt(tx_modifiable: Tapyrus::PSTT::TxModifiable::INPUTS | Tapyrus::PSTT::TxModifiable::OUTPUTS)
+      expect(pstt.tx_modifiable).to eq(0)
+      expect { pstt.tx_modifiable = Tapyrus::PSTT::TxModifiable::INPUTS }.to raise_error(
+        Tapyrus::PSTT::Error,
+        "PSTT_GLOBAL_TX_MODIFIABLE must not be relaxed once the PSTT contains signatures."
+      )
+      expect(pstt.tx_modifiable).to eq(0)
+    end
+
+    it "does not clear the Has SIGHASH_SINGLE flag once a signature has been collected" do
+      pstt =
+        signed_pstt(
+          tx_modifiable: Tapyrus::PSTT::TxModifiable::INPUTS,
+          sighash_type: Tapyrus::SIGHASH_TYPE[:single] | Tapyrus::SIGHASH_TYPE[:anyonecanpay]
+        )
+      expect(pstt.has_sighash_single?).to be true
+      expect { pstt.tx_modifiable = 0 }.to raise_error(Tapyrus::PSTT::Error, /must not be relaxed/)
+    end
+
+    it "still tightens PSTT_GLOBAL_TX_MODIFIABLE after a signature has been collected" do
+      pstt =
+        signed_pstt(
+          tx_modifiable: Tapyrus::PSTT::TxModifiable::INPUTS,
+          sighash_type: Tapyrus::SIGHASH_TYPE[:all] | Tapyrus::SIGHASH_TYPE[:anyonecanpay]
+        )
+      expect(pstt.inputs_modifiable?).to be true
+      pstt.tx_modifiable = 0
+      expect(pstt.inputs_modifiable?).to be false
+    end
+  end
+
+  describe "the Updater's sequence number restriction" do
+    let(:prev_tx) { funding_tx([100_000, p2pkh(keys[0])]) }
+    let(:other_tx) { funding_tx([100_000, p2pkh(keys[1])]) }
+
+    def two_input_pstt
+      Tapyrus::PSTT::Tx.new(
+        inputs: [pstt_input(prev_tx, 0), pstt_input(other_tx, 0)],
+        outputs: [pstt_output(199_000, p2pkh(keys[2]))]
+      )
+    end
+
+    it "sets the sequence number while no signature commits to it" do
+      pstt = two_input_pstt
+      pstt.set_sequence(0, 0xfffffffe)
+      expect(pstt.inputs.first.sequence).to eq(0xfffffffe)
+      expect(pstt.build_tx.inputs.first.sequence).to eq(0xfffffffe)
+      expect(pstt.build_tx.inputs.last.sequence).to eq(Tapyrus::TxIn::SEQUENCE_FINAL)
+    end
+
+    it "does not change the sequence number of a signed input" do
+      pstt = two_input_pstt
+      pstt.sign(0, keys[0], sighash_type: Tapyrus::SIGHASH_TYPE[:none])
+      expect { pstt.set_sequence(0, 0xfffffffe) }.to raise_error(Tapyrus::PSTT::Error, /already signed/)
+    end
+
+    it "does not change the sequence number of another input while a SIGHASH_ALL signature exists" do
+      pstt = two_input_pstt
+      pstt.sign(0, keys[0])
+      expect { pstt.set_sequence(1, 0xfffffffe) }.to raise_error(
+        Tapyrus::PSTT::Error,
+        /commits to the sequence number of every input/
+      )
+    end
+
+    it "allows changing another input's sequence number when the signature does not commit to it" do
+      pstt = two_input_pstt
+      pstt.sign(0, keys[0], sighash_type: Tapyrus::SIGHASH_TYPE[:none])
+      pstt.set_sequence(1, 0xfffffffe)
+      expect(pstt.inputs.last.sequence).to eq(0xfffffffe)
+    end
+
+    it "does not change the sequence number of an unsigned input while another input is finalized" do
+      pstt = two_input_pstt
+      pstt.sign(0, keys[0])
+      # Finalizing input 0 removes its PSTT_IN_PARTIAL_SIG records, so the sighash types of the
+      # signatures it was built from can no longer be read - but its SIGHASH_ALL signature still
+      # commits to the sequence number of input 1.
+      pstt.inputs.first.finalize!(pstt.verified_partial_sigs(0))
+      expect(pstt.inputs.first.partial_sigs).to be_empty
+      expect { pstt.set_sequence(1, 0xfffffffe) }.to raise_error(
+        Tapyrus::PSTT::Error,
+        /A finalized input carries signatures/
+      )
+    end
+
+    it "does not change the sequence number of a finalized input" do
+      pstt = two_input_pstt
+      pstt.sign(0, keys[0], sighash_type: Tapyrus::SIGHASH_TYPE[:none])
+      pstt.inputs.first.finalize!(pstt.verified_partial_sigs(0))
+      expect { pstt.set_sequence(0, 0xfffffffe) }.to raise_error(Tapyrus::PSTT::Error, /already signed/)
+    end
+  end
+
+  describe "Input Finalizer" do
+    let(:prev_tx) { funding_tx([100_000, p2pkh(keys[0])]) }
+    let(:garbage_sig) { ("00".htb * 71) + [Tapyrus::SIGHASH_TYPE[:all]].pack("C") }
+
+    it "does not build a scriptSig from a signature which does not verify" do
+      pstt = Tapyrus::PSTT::Tx.new(inputs: [pstt_input(prev_tx, 0)], outputs: [pstt_output(99_000, p2pkh(keys[1]))])
+      pstt.inputs.first.partial_sigs[keys[0].pubkey] = garbage_sig
+      expect { pstt.finalize! }.to raise_error(
+        Tapyrus::PSTT::Error,
+        "No valid signature for the public key committed in the scriptPubKey."
+      )
+    end
+
+    it "does not let an invalid signature displace a valid one in a multisig input" do
+      redeem_script = Tapyrus::Script.to_multisig_script(2, [keys[0].pubkey, keys[1].pubkey, keys[2].pubkey])
+      p2sh = Tapyrus::Script.to_p2sh(redeem_script.to_hash160)
+      pstt =
+        Tapyrus::PSTT::Tx.new(
+          inputs: [pstt_input(funding_tx([100_000, p2sh]), 0)],
+          outputs: [pstt_output(99_000, p2pkh(keys[3]))]
+        )
+      pstt.inputs.first.redeem_script = redeem_script
+      # The invalid signature belongs to the first public key of the redeem script, so a
+      # finalizer which took the collected signatures at face value would put it into the
+      # scriptSig and leave one of the two valid ones unused.
+      pstt.inputs.first.partial_sigs[keys[0].pubkey] = garbage_sig
+      pstt.sign(0, keys[1])
+      pstt.sign(0, keys[2])
+      expect(pstt.verified_partial_sigs(0).keys).to contain_exactly(keys[1].pubkey, keys[2].pubkey)
+
+      pstt.finalize!
+      expect(pstt.extract_tx.verify_input_sig(0, p2sh)).to be true
+    end
+
+    it "counts only the valid signatures against the multisig threshold" do
+      redeem_script = Tapyrus::Script.to_multisig_script(2, [keys[0].pubkey, keys[1].pubkey])
+      p2sh = Tapyrus::Script.to_p2sh(redeem_script.to_hash160)
+      pstt =
+        Tapyrus::PSTT::Tx.new(
+          inputs: [pstt_input(funding_tx([100_000, p2sh]), 0)],
+          outputs: [pstt_output(99_000, p2pkh(keys[2]))]
+        )
+      pstt.inputs.first.redeem_script = redeem_script
+      pstt.inputs.first.partial_sigs[keys[0].pubkey] = garbage_sig
+      pstt.sign(0, keys[1])
+      expect { pstt.finalize! }.to raise_error(
+        Tapyrus::PSTT::Error,
+        "2 signatures are required, but only 1 of the collected ones are valid."
+      )
+    end
+
+    it "does not sign an input which is already finalized" do
+      pstt = Tapyrus::PSTT::Tx.new(inputs: [pstt_input(prev_tx, 0)], outputs: [pstt_output(99_000, p2pkh(keys[1]))])
+      pstt.sign(0, keys[0])
+      pstt.finalize!
+      expect { pstt.sign(0, keys[0]) }.to raise_error(
+        Tapyrus::PSTT::Error,
+        "Input 0 is finalized. It takes no further signature."
+      )
+      expect(pstt.inputs.first.partial_sigs).to be_empty
+    end
+  end
+
+  describe "Determining the Locktime" do
+    let(:prev_tx) { funding_tx([100_000, p2pkh(keys[0])]) }
+
+    def locktime_pstt(*inputs)
+      Tapyrus::PSTT::Tx.new(inputs: inputs, outputs: [pstt_output(99_000, p2pkh(keys[1]))])
+    end
+
+    it "falls back to PSTT_GLOBAL_FALLBACK_LOCKTIME when no input requires a locktime" do
+      pstt = locktime_pstt(pstt_input(prev_tx, 0))
+      expect(pstt.locktime).to eq(0)
+      pstt.fallback_locktime = 100
+      expect(pstt.locktime).to eq(100)
+      expect(pstt.build_tx.lock_time).to eq(100)
+    end
+
+    it "takes the maximum height-based locktime" do
+      first = pstt_input(prev_tx, 0).tap { |input| input.required_height_locktime = 100 }
+      second = pstt_input(funding_tx([1, p2pkh(keys[1])]), 0).tap { |input| input.required_height_locktime = 200 }
+      pstt = locktime_pstt(first, second)
+      pstt.fallback_locktime = 1_000
+      expect(pstt.locktime).to eq(200)
+    end
+
+    it "takes the maximum time-based locktime" do
+      input = pstt_input(prev_tx, 0).tap { |i| i.required_time_locktime = 1_700_000_000 }
+      expect(locktime_pstt(input).locktime).to eq(1_700_000_000)
+    end
+
+    it "prefers the height-based locktime when both kinds are acceptable" do
+      input =
+        pstt_input(prev_tx, 0).tap do |i|
+          i.required_height_locktime = 100
+          i.required_time_locktime = 1_700_000_000
+        end
+      expect(locktime_pstt(input).locktime).to eq(100)
+    end
+
+    it "raises when no locktime kind is acceptable to every input" do
+      first = pstt_input(prev_tx, 0).tap { |input| input.required_height_locktime = 100 }
+      second = pstt_input(funding_tx([1, p2pkh(keys[1])]), 0).tap { |i| i.required_time_locktime = 1_700_000_000 }
+      expect { locktime_pstt(first, second).locktime }.to raise_error(
+        Tapyrus::PSTT::Error,
+        /No locktime kind is acceptable/
+      )
+    end
+
+    it "rejects a required locktime which is out of range, both when writing and when reading" do
+      input = pstt_input(prev_tx, 0).tap { |i| i.required_time_locktime = 100 }
+      expect { locktime_pstt(input).to_payload }.to raise_error(Tapyrus::PSTT::Error, /PSTT_IN_REQUIRED_TIME_LOCKTIME/)
+      expect { Tapyrus::PSTT::Tx.parse_from_payload(payload_with_time_locktime(100)) }.to raise_error(
+        Tapyrus::PSTT::Error,
+        /PSTT_IN_REQUIRED_TIME_LOCKTIME/
+      )
+    end
+
+    it "rejects a required height locktime which is out of range, both when writing and when reading" do
+      [0, Tapyrus::PSTT::LOCKTIME_THRESHOLD].each do |height|
+        input = pstt_input(prev_tx, 0).tap { |i| i.required_height_locktime = height }
+        expect { locktime_pstt(input).to_payload }.to raise_error(
+          Tapyrus::PSTT::Error,
+          /PSTT_IN_REQUIRED_HEIGHT_LOCKTIME/
+        )
+      end
+    end
+
+    # A PSTT whose PSTT_IN_REQUIRED_TIME_LOCKTIME is out of range cannot be serialized by this
+    # implementation, so the parser is fed a hand-assembled payload instead.
+    def payload_with_time_locktime(value)
+      input = pstt_input(prev_tx, 0)
+      records = input.to_records << Tapyrus::PSTT::KeyValue.new(0x11, "".b, [value].pack("V"))
+      pstt = locktime_pstt(input)
+      Tapyrus::PSTT::MAGIC + Tapyrus::PSTT.serialize_map(pstt.global_records) + Tapyrus::PSTT.serialize_map(records) +
+        pstt.outputs.map(&:to_payload).join
+    end
+  end
+
+  describe "fee provider workflow" do
+    let(:color_id) { Tapyrus::Color::ColorIdentifier.reissuable(p2pkh(keys[0])) }
+    let(:token_tx) { funding_tx([100, Tapyrus::Script.to_cp2pkh(color_id, keys[0].hash160)]) }
+    let(:fee_tx) { funding_tx([1_000, p2pkh(keys[3])]) }
+
+    it "lets the provider add an exact-fee input after the user has signed" do
+      # The user creates and signs with SIGHASH_ALL | SIGHASH_ANYONECANPAY, leaving inputs modifiable.
+      user =
+        Tapyrus::PSTT::Tx.new(
+          tx_modifiable: Tapyrus::PSTT::TxModifiable::INPUTS,
+          inputs: [pstt_input(token_tx, 0)],
+          outputs: [pstt_output(100, Tapyrus::Script.to_cp2pkh(color_id, keys[1].hash160))]
+        )
+      sighash_type = Tapyrus::SIGHASH_TYPE[:all] | Tapyrus::SIGHASH_TYPE[:anyonecanpay]
+      user_sighash = user.sighash_for_input(0, sighash_type: sighash_type)
+      user.sign(0, keys[0], sighash_type: sighash_type)
+      expect(user.inputs_modifiable?).to be true
+
+      # The provider verifies the token balance, then adds the fee input and signs with SIGHASH_ALL.
+      provider = Tapyrus::PSTT::Tx.parse_from_payload(user.to_payload)
+      expect(provider.input_amounts[color_id]).to eq(provider.output_amounts[color_id])
+      provider.add_input(pstt_input(fee_tx, 0))
+      provider.sign(1, keys[3])
+      expect(provider.inputs_modifiable?).to be false
+
+      # The user's signature hash is unchanged by the added input.
+      expect(provider.sighash_for_input(0, sighash_type: sighash_type)).to eq(user_sighash)
+      expect(provider.fee).to eq(1_000)
+
+      provider.finalize!
+      tx = provider.extract_tx
+      expect(tx.verify_input_sig(0, token_tx.outputs.first.script_pubkey)).to be true
+      expect(tx.verify_input_sig(1, fee_tx.outputs.first.script_pubkey)).to be true
+    end
+  end
+
+  describe "Combiner" do
+    let(:prev_tx) { funding_tx([100_000, p2pkh(keys[0])]) }
+    let(:other_tx) { funding_tx([5_000, p2pkh(keys[2])]) }
+
+    def modifiable_pstt
+      Tapyrus::PSTT::Tx.new(
+        tx_modifiable: Tapyrus::PSTT::TxModifiable::INPUTS | Tapyrus::PSTT::TxModifiable::OUTPUTS,
+        inputs: [pstt_input(prev_tx, 0)],
+        outputs: [pstt_output(99_000, p2pkh(keys[1]))]
+      )
+    end
+
+    it "does not combine PSTTs with different identifiers" do
+      first = Tapyrus::PSTT::Tx.new(inputs: [pstt_input(prev_tx, 0)], outputs: [pstt_output(99_000, p2pkh(keys[1]))])
+      second = Tapyrus::PSTT::Tx.new(inputs: [pstt_input(prev_tx, 0)], outputs: [pstt_output(98_000, p2pkh(keys[1]))])
+      expect { first.combine(second) }.to raise_error(
+        Tapyrus::PSTT::Error,
+        "PSTTs with different identifiers must not be combined."
+      )
+    end
+
+    it "does not resurrect a modifiable flag which the Signer cleared" do
+      signed = modifiable_pstt
+      # A copy taken before the signature still has both flags set, and both copies identify as
+      # the same PSTT because the identifier does not depend on the signatures.
+      unsigned = Tapyrus::PSTT::Tx.parse_from_payload(signed.to_payload)
+      signed.sign(0, keys[0])
+      expect(signed.tx_modifiable).to eq(0)
+      expect(unsigned.tx_modifiable).to eq(3)
+
+      combined = unsigned.combine(signed)
+      expect(combined.tx_modifiable).to eq(0)
+      expect(combined.inputs.first.signed?).to be true
+      expect { combined.add_input(pstt_input(other_tx, 0)) }.to raise_error(
+        Tapyrus::PSTT::Error,
+        "Inputs are not modifiable."
+      )
+    end
+
+    it "keeps the Has SIGHASH_SINGLE flag of either PSTT" do
+      first = modifiable_pstt
+      second = Tapyrus::PSTT::Tx.parse_from_payload(first.to_payload)
+      second.sign(0, keys[0], sighash_type: Tapyrus::SIGHASH_TYPE[:single] | Tapyrus::SIGHASH_TYPE[:anyonecanpay])
+      expect(first.combine(second).has_sighash_single?).to be true
+      expect(second.combine(first).has_sighash_single?).to be true
+    end
+
+    it "does not combine PSTTs which disagree about a sequence number" do
+      first = Tapyrus::PSTT::Tx.new(inputs: [pstt_input(prev_tx, 0)], outputs: [pstt_output(99_000, p2pkh(keys[1]))])
+      second = Tapyrus::PSTT::Tx.parse_from_payload(first.to_payload)
+      first.set_sequence(0, 0xfffffffe)
+      # The identifier is computed with every sequence number set to 0, so it does not separate
+      # the two. Keeping one value would invalidate the signatures which commit to the other.
+      expect(first.identification_txid).to eq(second.identification_txid)
+      expect { first.combine(second) }.to raise_error(
+        Tapyrus::PSTT::Error,
+        "Input 0 has a different sequence number in the two PSTTs."
+      )
+    end
+  end
+
+  describe "BIP 32 derivation" do
+    it "carries the key origin of an input and an output" do
+      prev_tx = funding_tx([100_000, p2pkh(keys[0])])
+      pstt = Tapyrus::PSTT::Tx.new(inputs: [pstt_input(prev_tx, 0)], outputs: [pstt_output(99_000, p2pkh(keys[1]))])
+      origin = Tapyrus::PSTT::KeyOriginInfo.from_path("f05655ac", "m/44'/2377'/0'/0/0")
+      pstt.inputs.first.bip32_derivations[keys[0].pubkey] = origin
+      pstt.outputs.first.bip32_derivations[keys[1].pubkey] = origin
+
+      parsed = Tapyrus::PSTT::Tx.parse_from_payload(pstt.to_payload)
+      expect(parsed.inputs.first.bip32_derivations[keys[0].pubkey]).to eq(origin)
+      expect(parsed.outputs.first.bip32_derivations[keys[1].pubkey].path).to eq("m/44'/2377'/0'/0/0")
+      expect(parsed.outputs.first.bip32_derivations[keys[1].pubkey].fingerprint).to eq("f05655ac")
+    end
+
+    it "carries a global extended public key" do
+      seed = Tapyrus.sha256("tapyrusrb pstt spec").bth
+      account = Tapyrus::ExtKey.generate_master(seed).derive(44, true).derive(1, true).derive(0, true).ext_pubkey
+      pstt = Tapyrus::PSTT::Tx.new
+      pstt.xpubs[account.to_base58] = Tapyrus::PSTT::KeyOriginInfo.from_path(
+        Tapyrus::ExtKey.generate_master(seed).fingerprint,
+        "m/44'/1'/0'"
+      )
+      parsed = Tapyrus::PSTT::Tx.parse_from_payload(pstt.to_payload)
+      expect(parsed.xpubs.keys).to eq([account.to_base58])
+      expect(parsed.xpubs.values.first.path).to eq("m/44'/1'/0'")
+    end
+  end
+
+  describe "Proprietary" do
+    it "carries a proprietary record" do
+      pstt = Tapyrus::PSTT::Tx.new
+      pstt.proprietaries << Tapyrus::PSTT::Proprietary.new(
+        identifier: "tapyrusrb",
+        subtype: 1,
+        subkeydata: "01".htb,
+        value: "value"
+      )
+      parsed = Tapyrus::PSTT::Tx.parse_from_payload(pstt.to_payload)
+      expect(parsed.proprietaries.size).to eq(1)
+      expect(parsed.proprietaries.first.identifier).to eq("tapyrusrb")
+      expect(parsed.proprietaries.first.subtype).to eq(1)
+      expect(parsed.proprietaries.first.value).to eq("value")
+    end
+  end
+end


### PR DESCRIPTION
## **概要**
TIP-0174が定義するPSTT(Partially Signed Tapyrus Transaction)フォーマットを`Tapyrus::PSTT`として実装する。

## **詳細説明**
複数の参加者が1つのトランザクションを段階的に構築・署名するための共通フォーマットが、tapyrusrbには存在しなかった。特に、Colored Coinの取引において手数料を負担するTPCの入力を第三者(fee provider)が後から追加するユースケースでは、署名前のトランザクションと署名者が必要とするメタデータ(UTXO、sighash type、鍵の導出情報等)を相互運用可能な形で受け渡す手段が必要である。

データモデルはTIP-0174に従い、トランザクションを入力ごと・出力ごとのフィールドで表現する。これにより、作成後に入力と出力を追加できる。APIはTIPが定めるロール(Creator、Constructor、Updater、Signer、Combiner、Input Finalizer、Transaction Extractor)に対応させている。

## **変更内容**
- `lib/tapyrus/pstt.rb`: PSTTのキータイプ定義、compact size整数の最小エンコーディング検証、key-valueレコードのシリアライズ/デシリアライズを実装
- `lib/tapyrus/pstt/tx.rb`: グローバルマップと入出力の管理、`sign` / `combine` / `finalize!` / `extract_tx`、`tx_modifiable`によるinputs/outputsの変更可否制御、`input_amounts` / `output_amounts` / `fee`によるカラーごとの金額検証を実装
- `lib/tapyrus/pstt/input.rb`, `output.rb`, `key_origin_info.rb`, `proprietary.rb`: 各マップのフィールドを実装
- `lib/tapyrus.rb`: `Tapyrus::PSTT`をautoloadに追加
- `spec/tapyrus/pstt_spec.rb`, `spec/fixtures/tip0174/{valid,invalid}.json`: PSTTのテストとテストベクタを追加
- `spec/schnorr_spec.rb`: tapyrus-coreの決定的署名テストベクタによる検証を追加。
- `README.md`: PSTTの説明と使用例を追加
- `lib/tapyrus/version.rb`: 0.4.0にバージョンを更新

## **影響範囲**
- 新規モジュール`Tapyrus::PSTT`の追加のみであり、既存APIの変更はない
- `lib/tapyrus.rb`へのautoload追加と`version.rb`のバージョン更新が既存ファイルへの変更である

## **検証手順**
1. `bundle install`を実行する
2. `bundle exec rspec spec/tapyrus/pstt_spec.rb spec/schnorr_spec.rb`を実行し、全テストがパスすることを確認する
3. `bundle exec rspec`を実行し、既存テストにデグレードがないことを確認する
4. READMEの使用例のとおり、PSTTの作成、署名、`finalize!`、`extract_tx`が動作することを確認する

## **関連Issue**
- TIP-0174: https://github.com/chaintope/tips/blob/master/tip-0174.md
- https://github.com/chaintope/tapyrusjs-lib/pull/18

## **備考**
- バージョンを0.4.0に更新している。gemのリリースタイミングは別途調整が必要である
- Segregated WitnessおよびTaproot由来のキータイプはTapyrusでは意味を持たないため予約扱いとし、パース時に拒否する。一方でBIPが後から割り当てたMuSig2等のキータイプは列挙せず、unknownレコードとして保持する