### PR TITLE
fix: Preserve leading zero bytes of SLIP-39 share values

### DIFF
--- a/lib/tapyrus/slip39/share.rb
+++ b/lib/tapyrus/slip39/share.rb
@@ -48,7 +48,7 @@ module Tapyrus
         end_index = start_index + value_length - padding_length
         padding_value = data[40...(40 + padding_length)]
         raise ArgumentError, "Invalid mnemonic. padding must only zero." unless padding_value.to_i(2) == 0
-        s.value = data[start_index...end_index].to_i(2).to_even_length_hex
+        s.value = data[start_index...end_index].to_i(2).to_s(16).rjust((value_length - padding_length) / 4, "0")
         s.checksum = data[(40 + value_length)..-1].to_i(2)
         s
       end
@@ -105,8 +105,8 @@ module Tapyrus
         end
         s << member_index.to_bits(4)
         s << (member_threshold - 1).to_bits(4)
-        value_length = value.to_i(16).bit_length
-        padding_length = RADIX_BITS - (value_length % RADIX_BITS)
+        value_length = value.htb.bytesize * 8
+        padding_length = (RADIX_BITS - (value_length % RADIX_BITS)) % RADIX_BITS
         s << value.to_i(16).to_bits(value_length + padding_length)
         s << checksum.to_bits(30) if include_checksum
         s.chars.each_slice(10).map { |index| index.join.to_i(2) }

--- a/lib/tapyrus/slip39/share.rb
+++ b/lib/tapyrus/slip39/share.rb
@@ -105,6 +105,12 @@ module Tapyrus
         end
         s << member_index.to_bits(4)
         s << (member_threshold - 1).to_bits(4)
+        # from_words derives the padding length from the number of value words modulo 16, which only
+        # matches the padding written here when the value is an even number of bytes. An odd one is
+        # read back as a different value instead of being rejected.
+        unless value.htb.bytesize.even?
+          raise ArgumentError, "The length of the share value in bytes must be an even number."
+        end
         value_length = value.htb.bytesize * 8
         padding_length = (RADIX_BITS - (value_length % RADIX_BITS)) % RADIX_BITS
         s << value.to_i(16).to_bits(value_length + padding_length)

--- a/spec/tapyrus/slip39_spec.rb
+++ b/spec/tapyrus/slip39_spec.rb
@@ -216,4 +216,33 @@ describe Tapyrus::SLIP39 do
       expect(Tapyrus::SLIP39::SSS.recover_secret(shares, passphrase: "TREZOR")).not_to eq(master_secret_128)
     end
   end
+
+  describe "share value with leading zero byte" do
+    def build_share(value)
+      share = Tapyrus::SLIP39::Share.new
+      share.id = 1234
+      share.iteration_exp = 0
+      share.group_index = 0
+      share.group_threshold = 1
+      share.group_count = 1
+      share.member_index = 0
+      share.member_threshold = 1
+      share.value = value
+      share.checksum = share.calculate_checksum
+      share
+    end
+
+    it "should round trip through mnemonic words." do
+      ["00" + "11" * 15, "0000" + "22" * 30, "00" * 15 + "01"].each do |value|
+        share = build_share(value)
+        words = share.to_words
+        recovered = Tapyrus::SLIP39::Share.from_words(words)
+        expect(recovered.value).to eq(value)
+      end
+    end
+
+    it "should generate the same number of words as a value without a leading zero byte." do
+      expect(build_share("00" + "11" * 31).to_words.size).to eq(build_share("ff" * 32).to_words.size)
+    end
+  end
 end

--- a/spec/tapyrus/slip39_spec.rb
+++ b/spec/tapyrus/slip39_spec.rb
@@ -228,13 +228,18 @@ describe Tapyrus::SLIP39 do
       share.member_index = 0
       share.member_threshold = 1
       share.value = value
+      share
+    end
+
+    def build_share_with_checksum(value)
+      share = build_share(value)
       share.checksum = share.calculate_checksum
       share
     end
 
     it "should round trip through mnemonic words." do
       ["00" + "11" * 15, "0000" + "22" * 30, "00" * 15 + "01"].each do |value|
-        share = build_share(value)
+        share = build_share_with_checksum(value)
         words = share.to_words
         recovered = Tapyrus::SLIP39::Share.from_words(words)
         expect(recovered.value).to eq(value)
@@ -242,7 +247,19 @@ describe Tapyrus::SLIP39 do
     end
 
     it "should generate the same number of words as a value without a leading zero byte." do
-      expect(build_share("00" + "11" * 31).to_words.size).to eq(build_share("ff" * 32).to_words.size)
+      expect(build_share_with_checksum("00" + "11" * 31).to_words.size).to eq(
+        build_share_with_checksum("ff" * 32).to_words.size
+      )
+    end
+
+    it "should reject a value which is not an even number of bytes." do
+      # A 25-byte value with a leading zero byte is the case this guard exists for. The padding
+      # from_words assumes is one byte wider than the one to_words writes, so without the check the
+      # value comes back as a different 24-byte value rather than as an error.
+      expect { build_share("00" + "ab" * 24).to_words }.to raise_error(
+        ArgumentError,
+        "The length of the share value in bytes must be an even number."
+      )
     end
   end
 end


### PR DESCRIPTION

## Summary

A SLIP-39 share whose value begins with a `0x00` byte produces a mnemonic that this library cannot decode. `Share#to_words` succeeds, but feeding the result back into `Share.from_words` raises `ArgumentError: Invalid mnemonic length.` A backup written to paper is silently unrecoverable.

Measured rate: 13 out of 6000 shares (0.22%) generated by `SSS.setup_shares(group_threshold: 1, groups: [[2, 3]])` failed to round trip.

## Details

Two places in `lib/tapyrus/slip39/share.rb` derive the length of the share value from its integer representation, which discards leading zero bytes.

`build_word_indices` computed the bit length with `Integer#bit_length`:

```ruby
value_length = value.to_i(16).bit_length
```

For a 32-byte value starting with `0x00` this yields 248 instead of 256, so the mnemonic is one word short of what the specification requires.

`from_words` converted the recovered bits back to hex with `Integer#to_even_length_hex`, which only pads to a whole byte and cannot restore a leading `00`. Even with the writing side fixed, the recovered value would be shorter than the original and `SSS.recover_secret` would reject it at the "all share values must have the same length" check.

## Changes

`lib/tapyrus/slip39/share.rb`

- `build_word_indices` derives the bit length from the byte size of the value (`value.htb.bytesize * 8`).
- The padding length takes an extra `% RADIX_BITS` so that a value whose bit length is already a multiple of 10 does not gain a spurious all-zero word.
- `from_words` pads the recovered hex to the exact length implied by the bit count instead of merely rounding up to a whole byte.

`spec/tapyrus/slip39_spec.rb`

- Adds a round trip test for share values with one or more leading zero bytes.
- Adds a test that a value with a leading zero byte yields the same word count as a value without one.

Both new examples fail on `master` and pass with this change.

## Impact

- `Tapyrus::SLIP39::Share#to_words` and `Tapyrus::SLIP39::Share.from_words`.
- Values that do not begin with `0x00` are encoded exactly as before, so existing backups are unaffected. All examples in `spec/fixtures/slip39/vectors.json` still pass.
- Mnemonics previously written out for a share value starting with `0x00` were already undecodable and remain so. Such a backup has to be regenerated.

## How to verify

```
bundle exec rspec spec/tapyrus/slip39_spec.rb
```

49 examples, 0 failures.

To confirm the original defect, run the following against `master`:

```ruby
share = Tapyrus::SLIP39::Share.new
share.id = 1234
share.iteration_exp = 0
share.group_index = 0
share.group_threshold = 1
share.group_count = 1
share.member_index = 0
share.member_threshold = 1
share.value = "00" + "11" * 31
share.checksum = share.calculate_checksum
Tapyrus::SLIP39::Share.from_words(share.to_words)
# => ArgumentError: Invalid mnemonic length.
```

## Related issues

None.

## Notes

`SSS.get_salt` builds the PBKDF2 salt with `id.itb`, which yields one byte when the identifier is below 256 instead of the two bytes the specification requires. That breaks interoperability with other SLIP-39 implementations for roughly 0.78% of identifiers. It is a separate defect and is not addressed here.
