### PR TITLE
fix: Reject a PSTT script field which is not the serialization of a script

### DIFF
--- a/lib/tapyrus/pstt.rb
+++ b/lib/tapyrus/pstt.rb
@@ -272,6 +272,24 @@ module Tapyrus
         raise Error, "#{name} is malformed. #{e.message}"
       end
 
+      # Parse the value of a script field.
+      #
+      # Tapyrus::Script.parse_from_payload accepts a pushdata which runs past the end of the payload
+      # and drops it, so a value such as 4d0001 parses without an error and serializes back as 00. A
+      # Combiner must not change a record it did not produce, so a value which does not serialize back
+      # to the bytes it was read from is rejected here instead.
+      # @param [String] name the name of the field, used in the error message.
+      # @param [String] payload the value of the record with binary format.
+      # @return [Tapyrus::Script] the script.
+      # @raise [Tapyrus::PSTT::Error] if the value is not a script, or is not the serialization of one.
+      def parse_script_field(name, payload)
+        script = parse_field(name) { Tapyrus::Script.parse_from_payload(payload) }
+        unless script.to_payload == payload
+          raise Error, "#{name} is malformed. The value is not the serialization of a script."
+        end
+        script
+      end
+
       # Check that +hash_type+ is one of the sighash types TIP-0174 defines.
       # @param [Integer] hash_type a sighash type.
       # @raise [Tapyrus::PSTT::Error] if it is not.

--- a/lib/tapyrus/pstt/input.rb
+++ b/lib/tapyrus/pstt/input.rb
@@ -115,15 +115,13 @@ module Tapyrus
             PSTT.validate_sighash_type!(input.sighash_type)
           when InputTypes::REDEEM_SCRIPT
             PSTT.validate_empty_keydata!(record)
-            input.redeem_script =
-              PSTT.parse_field("PSTT_IN_REDEEM_SCRIPT") { Tapyrus::Script.parse_from_payload(record.value) }
+            input.redeem_script = PSTT.parse_script_field("PSTT_IN_REDEEM_SCRIPT", record.value)
           when InputTypes::BIP32_DERIVATION
             PSTT.validate_pubkey_keydata!(record)
             input.bip32_derivations[record.keydata.bth] = KeyOriginInfo.parse_from_payload(record.value)
           when InputTypes::FINAL_SCRIPTSIG
             PSTT.validate_empty_keydata!(record)
-            input.final_script_sig =
-              PSTT.parse_field("PSTT_IN_FINAL_SCRIPTSIG") { Tapyrus::Script.parse_from_payload(record.value) }
+            input.final_script_sig = PSTT.parse_script_field("PSTT_IN_FINAL_SCRIPTSIG", record.value)
           when InputTypes::RIPEMD160, InputTypes::HASH160
             raise Error, "The preimage hash must be 20 bytes." unless record.keydata.bytesize == 20
             input.preimages_for(record.type)[record.keydata.bth] = record.value

--- a/lib/tapyrus/pstt/output.rb
+++ b/lib/tapyrus/pstt/output.rb
@@ -54,8 +54,7 @@ module Tapyrus
           case record.type
           when OutputTypes::REDEEM_SCRIPT
             PSTT.validate_empty_keydata!(record)
-            output.redeem_script =
-              PSTT.parse_field("PSTT_OUT_REDEEM_SCRIPT") { Tapyrus::Script.parse_from_payload(record.value) }
+            output.redeem_script = PSTT.parse_script_field("PSTT_OUT_REDEEM_SCRIPT", record.value)
           when OutputTypes::BIP32_DERIVATION
             PSTT.validate_pubkey_keydata!(record)
             output.bip32_derivations[record.keydata.bth] = KeyOriginInfo.parse_from_payload(record.value)
@@ -65,8 +64,7 @@ module Tapyrus
             PSTT.validate_amount!(output.amount)
           when OutputTypes::SCRIPT
             PSTT.validate_empty_keydata!(record)
-            output.script_pubkey =
-              PSTT.parse_field("PSTT_OUT_SCRIPT") { Tapyrus::Script.parse_from_payload(record.value) }
+            output.script_pubkey = PSTT.parse_script_field("PSTT_OUT_SCRIPT", record.value)
           when OutputTypes::PROPRIETARY
             output.proprietaries << Proprietary.parse_from_record(record)
           else

--- a/spec/fixtures/tip0174/invalid.json
+++ b/spec/fixtures/tip0174/invalid.json
@@ -240,6 +240,46 @@
     }
   },
   {
+    "id": "input-redeem-script-not-a-script",
+    "description": "PSTT_IN_REDEEM_SCRIPT carries 4d0001, a PUSHDATA2 whose length runs past the end of the value. Tapyrus::Script drops the pushdata, so the record would serialize back as 00.",
+    "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQIAAQQDTQABAQ4geCTV5dcUOipMfUFAlCGn4hY8MWRwPqiSbffTGnvs0dQBDwQAAAAAAAEDCGDqAAAAAAAAAQQZdqkUVxopLcEbtHFwMPBNVkWsQvKuYN+IrAABAwhYmAAAAAAAAAEEGXapFOVxZknojyIueLwhSn+ibr05gJzRiKwA",
+    "expected": {
+      "valid": false,
+      "stage": "parse",
+      "reason": "PSTT_IN_REDEEM_SCRIPT is not the serialization of a script"
+    }
+  },
+  {
+    "id": "input-final-scriptsig-not-a-script",
+    "description": "PSTT_IN_FINAL_SCRIPTSIG carries 4d0001, a PUSHDATA2 whose length runs past the end of the value. Tapyrus::Script drops the pushdata, so the record would serialize back as 00.",
+    "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQIAAQcDTQABAQ4geCTV5dcUOipMfUFAlCGn4hY8MWRwPqiSbffTGnvs0dQBDwQAAAAAAAEDCGDqAAAAAAAAAQQZdqkUVxopLcEbtHFwMPBNVkWsQvKuYN+IrAABAwhYmAAAAAAAAAEEGXapFOVxZknojyIueLwhSn+ibr05gJzRiKwA",
+    "expected": {
+      "valid": false,
+      "stage": "parse",
+      "reason": "PSTT_IN_FINAL_SCRIPTSIG is not the serialization of a script"
+    }
+  },
+  {
+    "id": "output-redeem-script-not-a-script",
+    "description": "PSTT_OUT_REDEEM_SCRIPT carries 4d0001, a PUSHDATA2 whose length runs past the end of the value. Tapyrus::Script drops the pushdata, so the record would serialize back as 00.",
+    "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQIAAQ4geCTV5dcUOipMfUFAlCGn4hY8MWRwPqiSbffTGnvs0dQBDwQAAAAAAAEAA00AAQEDCGDqAAAAAAAAAQQZdqkUVxopLcEbtHFwMPBNVkWsQvKuYN+IrAABAwhYmAAAAAAAAAEEGXapFOVxZknojyIueLwhSn+ibr05gJzRiKwA",
+    "expected": {
+      "valid": false,
+      "stage": "parse",
+      "reason": "PSTT_OUT_REDEEM_SCRIPT is not the serialization of a script"
+    }
+  },
+  {
+    "id": "output-script-not-a-script",
+    "description": "PSTT_OUT_SCRIPT carries 4d0001, a PUSHDATA2 whose length runs past the end of the value. Tapyrus::Script drops the pushdata, so the record would serialize back as 00.",
+    "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQIAAQ4geCTV5dcUOipMfUFAlCGn4hY8MWRwPqiSbffTGnvs0dQBDwQAAAAAAAEDCGDqAAAAAAAAAQQDTQABAAEDCFiYAAAAAAAAAQQZdqkU5XFmSeiPIi54vCFKf6JuvTmAnNGIrAA=",
+    "expected": {
+      "valid": false,
+      "stage": "parse",
+      "reason": "PSTT_OUT_SCRIPT is not the serialization of a script"
+    }
+  },
+  {
     "id": "truncated-value",
     "description": "The final output map's PSTT_OUT_SCRIPT record declares a valuelen one byte longer than the data actually present in the buffer.",
     "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEAAQ4gAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBDwQAAAAAAAEDCECcAAAAAAAAAQQadqkUAAAAAAAAAAAAAAAAAAAAAAAAAACIrA==",

--- a/spec/tapyrus/pstt_spec.rb
+++ b/spec/tapyrus/pstt_spec.rb
@@ -92,6 +92,20 @@ RSpec.describe Tapyrus::PSTT do
         )
       end
 
+      it "detects a script field which is not the serialization of a script" do
+        {
+          "input-redeem-script-not-a-script" => "PSTT_IN_REDEEM_SCRIPT",
+          "input-final-scriptsig-not-a-script" => "PSTT_IN_FINAL_SCRIPTSIG",
+          "output-redeem-script-not-a-script" => "PSTT_OUT_REDEEM_SCRIPT",
+          "output-script-not-a-script" => "PSTT_OUT_SCRIPT"
+        }.each do |id, field|
+          expect { Tapyrus::PSTT::Tx.from_base64(invalid_vector(id)) }.to raise_error(
+            Tapyrus::PSTT::Error,
+            "#{field} is malformed. The value is not the serialization of a script."
+          )
+        end
+      end
+
       it "detects a keytype which is not minimally encoded" do
         expect { Tapyrus::PSTT::Tx.from_base64(invalid_vector("non-minimal-keytype")) }.to raise_error(
           Tapyrus::PSTT::Error,
@@ -363,6 +377,19 @@ RSpec.describe Tapyrus::PSTT do
         Tapyrus::PSTT::Error,
         /PSTT_OUT_AMOUNT must be between/
       )
+    end
+
+    it "keeps a script field whose pushdata is not minimally encoded" do
+      # 4c05 is a PUSHDATA1 of 5 bytes, which 05 also expresses. Both are scripts, so the record
+      # must reach the next role with the bytes it was written with.
+      script = Tapyrus::Script.parse_from_payload("4c050102030405".htb)
+      pstt = one_input_pstt
+      pstt.inputs.first.redeem_script = script
+      payload = pstt.to_payload
+
+      parsed = Tapyrus::PSTT::Tx.parse_from_payload(payload)
+      expect(parsed.inputs.first.redeem_script.to_payload.bth).to eq("4c050102030405")
+      expect(parsed.to_payload).to eq(payload)
     end
   end
 


### PR DESCRIPTION

## Summary

The four script fields of a PSTT (`PSTT_IN_REDEEM_SCRIPT`, `PSTT_IN_FINAL_SCRIPTSIG`, `PSTT_OUT_REDEEM_SCRIPT`, `PSTT_OUT_SCRIPT`) accepted a value which is not the serialization of a script, and turned it into different bytes when the PSTT was serialized again.

`Tapyrus::Script.parse_from_payload` accepts a pushdata whose length runs past the end of the payload and drops it, without raising.

```
Tapyrus::Script.parse_from_payload("4d0001".htb).to_payload.bth
#=> "00"
```

A PSTT carrying `4d0001` in one of those fields therefore parsed, and the record came out as `00`. TIP-0174 requires a Combiner to leave a record it did not produce unchanged, so a role which only reads and writes a PSTT must not alter it. The change was silent: no exception, no warning, and the field kept a value that looked plausible.

`PSTT_IN_UTXO` already guards against the same class of problem in `parse_utxo`, which rejects a value whose transaction does not serialize back to the bytes it was read from. The script fields had no equivalent.

## Details

`PSTT.parse_script_field(name, payload)` parses the value and compares the serialization of the result against the bytes it was read from. A mismatch raises `Tapyrus::PSTT::Error`. The four call sites use it.

A script whose pushdata is not minimally encoded is still accepted. `4c05` pushes 5 bytes where `05` would also do, and both are valid scripts; `Tapyrus::Script` reproduces either form exactly, so the guard does not reject it. The only values the guard rejects are those which cannot be serialized back, that is, a pushdata which runs past the end of the value.

## Changes

`lib/tapyrus/pstt.rb`

- Adds `PSTT.parse_script_field`.

`lib/tapyrus/pstt/input.rb`, `lib/tapyrus/pstt/output.rb`

- `PSTT_IN_REDEEM_SCRIPT`, `PSTT_IN_FINAL_SCRIPTSIG`, `PSTT_OUT_REDEEM_SCRIPT` and `PSTT_OUT_SCRIPT` go through the new helper.

`spec/fixtures/tip0174/invalid.json`

- Four vectors, one per field, each carrying `4d0001` as the value of that field.

`spec/tapyrus/pstt_spec.rb`

- Asserts the error message of each of the four vectors.
- Asserts that a redeem script with a non minimally encoded pushdata is accepted, is readable as the script it was written as, and survives a byte exact round trip. This is what keeps the guard from growing into a rejection of valid scripts.

The four vectors and the message assertion fail on `master`. The non minimal pushdata example passes on `master` as well, which is the point of it.

## Impact

- The parsers of `Tapyrus::PSTT::Input` and `Tapyrus::PSTT::Output`.
- A PSTT whose script fields hold valid scripts parses exactly as before, byte for byte.
- A PSTT which used to parse and then serialize to different bytes is now rejected at parse time with `Tapyrus::PSTT::Error`. A caller which passes such a payload receives an error where it used to receive an altered PSTT. That is the intent: the value was never the serialization of a script, and carrying it further would have corrupted the record for every later role.

## How to verify

```
bundle exec rspec spec/tapyrus/pstt_spec.rb
```

141 examples, 0 failures.

The full suite reports 2632 examples with 24 failures, all of which are present on `master` (2626 examples, 24 failures) and unrelated to this change.

To confirm the original defect on `master`, parse the `input-redeem-script-not-a-script` vector, whose `PSTT_IN_REDEEM_SCRIPT` holds `4d0001`:

```ruby
base64 =
  "cHN0dP8BAgQBAAAAAQQBAQEFAQIAAQQDTQABAQ4geCTV5dcUOipMfUFAlCGn4hY8MWRwPqiSbffTGnvs0dQBDwQAAAAAAAEDCGDqAAAAAAAAAQQZdqkUVxopLcEbtHFwMPBNVkWsQvKuYN+IrAABAwhYmAAAAAAAAAEEGXapFOVxZknojyIueLwhSn+ibr05gJzRiKwA"
pstt = Tapyrus::PSTT::Tx.from_base64(base64)
pstt.inputs.first.redeem_script.to_payload.bth  #=> "00"
pstt.to_payload == base64.unpack1("m0")         #=> false
```

With this change the same payload raises `Tapyrus::PSTT::Error`.

## Related issues

None.

## Notes

`Tapyrus::Script.parse_from_payload` itself still accepts a truncated pushdata. Changing that would affect transaction parsing and script evaluation, so it is left alone here; this pull request only stops the PSTT container from carrying such a value.